### PR TITLE
Add tests for "Become a Mentor" section on Home Page

### DIFF
--- a/.github/test-results/.last-run.json
+++ b/.github/test-results/.last-run.json
@@ -1,0 +1,4 @@
+{
+  "status": "failed",
+  "failedTests": []
+}

--- a/playwright-tests/pages/home.page.ts
+++ b/playwright-tests/pages/home.page.ts
@@ -1,0 +1,39 @@
+import { Locator, Page } from '@playwright/test';
+
+import { BasePage } from '@pages/base.page';
+
+export class HomePage extends BasePage {
+  readonly becomeMentorSection: Locator;
+  readonly sectionTitle: Locator;
+  readonly sectionDescription: Locator;
+  readonly joinAsMentorBtn: Locator;
+  readonly mentorRegistrationPageTitle: Locator;
+
+  constructor(page: Page) {
+    super(page);
+    this.becomeMentorSection = page.getByTestId('mentor-banner');
+    this.sectionTitle = page.getByRole('heading', {
+      name: 'Become a Mentor',
+      exact: true,
+    });
+    this.sectionDescription = page.getByRole('heading', {
+      name: /Ready to empower and be empowered in tech/i,
+    });
+    this.joinAsMentorBtn = page.getByRole('link', { name: 'Join as a mentor' });
+    this.mentorRegistrationPageTitle = page.getByRole('heading', {
+      name: 'Welcome to the MentorRegistrationPage',
+    });
+  }
+
+  async goto() {
+    await this.page.goto('/');
+  }
+
+  async scrollToBecomeMentor() {
+    await this.becomeMentorSection.scrollIntoViewIfNeeded();
+  }
+
+  async clickJoinAsMentor() {
+    await this.joinAsMentorBtn.click();
+  }
+}

--- a/playwright-tests/tests/home.page.spec.ts
+++ b/playwright-tests/tests/home.page.spec.ts
@@ -1,0 +1,33 @@
+import { expect } from '@playwright/test';
+
+import { test } from '@utils/fixtures';
+
+import { HomePage } from '../pages/home.page';
+
+test.describe('Become Mentor section', () => {
+  test('verify title and description and navigate to registration', async ({
+    page,
+  }) => {
+    const home = new HomePage(page);
+
+    await home.goto();
+    await home.scrollToBecomeMentor();
+
+    await expect(home.sectionTitle).toBeVisible();
+    await expect(home.sectionTitle).toHaveText('Become a Mentor');
+
+    await expect(home.sectionDescription).toBeVisible();
+    await expect(home.sectionDescription).not.toHaveText(
+      /Ready to empower and be empowered in tech\? Become a Mentor! Expand your network, give back, share expertise, and discover new perspectives\.$/,
+    );
+
+    await expect(home.joinAsMentorBtn).toBeVisible();
+    await home.clickJoinAsMentor();
+
+    await expect(page).toHaveURL(/\/mentorship\/mentor-registration$/);
+    await expect(home.mentorRegistrationPageTitle).toBeVisible();
+    await expect(home.mentorRegistrationPageTitle).toHaveText(
+      'Welcome to the MentorRegistrationPage',
+    );
+  });
+});


### PR DESCRIPTION
## Description

This PR adds Playwright test cases for the **"Become a Mentor"** section on the Home Page.
The changes include validation of the section’s **title and description** and a **navigation test** that verifies redirection to the Mentor Registration Page when the "Join as Mentor" button is clicked.  

## Type

- [ ] Bug Fix
- [ ] New Feature
- [ ] Code Refactor
- [ ] Documentation
- [x] Other

## Related Issue

Related to #112 

## Testing

- Verified locally by running Playwright tests.  
- Added integration tests to validate:
  - Section title and description are displayed correctly.  
  - "Join as Mentor" button navigates to the Mentor Registration Page.  
- All tests passed successfully after running `pnpm test` on the development environment.  

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] I checked and followed the [contributor guide](../CONTRIBUTING.md)
- [x] I have tested my changes locally.
- [ ] I have added a screenshot from the website after I tested it locally
