### PR TITLE
Ignore playwright-tests directory

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -64,6 +64,7 @@
       }
     }
   ],
+  "ignorePatterns": ["playwright-tests/"],
   "settings": {
     "react": {
       "version": "detect"


### PR DESCRIPTION
## Description

Added playwright-tests/ to ESLint ignore patterns so that test files are excluded from linting.

## Type

- [ ] Bug Fix
- [ ] New Feature
- [ ] Code Refactor
- [ ] Documentation
- [x] Chore

## Related Issue

Pre-commit hook failed with 'itemTitle' is defined but never used in playwright-tests/pages/base.page.ts.

## Screenshots

<!--  If you are adding or changing a component or page, styling it is mandatory to add a screenshot of your work. -->
<!-- If your component is not visible at the current time of the application (e.g. creating a reusable component before using it), add a screenshot how it would look like per the design and when you used it in your local development >
<!--  Please add screenshot from *before* and *after* to simply the code review -->

## Testing

	•	Ran ESLint normally → playwright-tests/ is skipped (No files matching shown).
	•	Ran ESLint with --no-ignore → test files were linted and errors appeared as expected.
```sh
npx eslint "playwright-tests" --ext .ts,.tsx,.js,.jsx          # skipped
npx eslint "playwright-tests" --ext .ts,.tsx,.js,.jsx --no-ignore  # errors shown
```

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] I checked and followed the [contributor guide](../CONTRIBUTING.md)
- [x] I have tested my changes locally.
- [ ] I have added a screenshot from the website after I tested it locally

<!--  Thanks for sending a pull request! -->
