### PR TITLE
Mentorship FAQ Page Implementation

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -64,6 +64,7 @@
       }
     }
   ],
+  "ignorePatterns": ["playwright-tests/"],
   "settings": {
     "react": {
       "version": "detect"

--- a/playwright-tests/pages/base.page.ts
+++ b/playwright-tests/pages/base.page.ts
@@ -22,7 +22,8 @@ export class BasePage {
     this.blogLink = page.getByRole('button', { name: 'Blog' });
     this.jobsLink = page.getByRole('button', { name: 'Jobs' });
     this.aboutUsDropdown = page.getByRole('button', { name: 'About Us' });
-    this.menuitem = (itemTitle: string) => page.getByRole('menuitem', { name: itemTitle });
+    this.menuitem = (itemTitle: string) =>
+      page.getByRole('menuitem', { name: itemTitle });
   }
 
   async navigateToPath(path: string) {

--- a/playwright-tests/tests/about-us-dropdown-items.page.spec.ts
+++ b/playwright-tests/tests/about-us-dropdown-items.page.spec.ts
@@ -1,18 +1,14 @@
-import { test } from '@utils/fixtures';
 import { aboutUsMenuItems } from '@utils/datafactory/about-us-dropdown-items.tests';
+import { test } from '@utils/fixtures';
 
 test.describe('About Us Dropdown Navigation', () => {
   test('NAV-012: Click and navigate through About Us dropdown items', async ({
     basePage,
   }) => {
-   
-   
     for (const { name, expectedURL, expectedText } of aboutUsMenuItems) {
-        await basePage.navigateToPath('/');
+      await basePage.navigateToPath('/');
       await basePage.clickElement(basePage.aboutUsDropdown);
-      await basePage.clickElement(
-        basePage.menuitem(name),
-      );
+      await basePage.clickElement(basePage.menuitem(name));
       await basePage.verifyURL(expectedURL);
       await basePage.verifyPageContainsText(expectedText);
     }

--- a/playwright-tests/utils/datafactory/about-us-dropdown-items.tests.ts
+++ b/playwright-tests/utils/datafactory/about-us-dropdown-items.tests.ts
@@ -1,10 +1,42 @@
 export const aboutUsMenuItems = [
-  { name: 'Overview', expectedURL: '/about-us', expectedText: 'Welcome to the AboutUsPage' },
-  { name: 'Team', expectedURL: '/about-us/team', expectedText: 'Welcome to the TeamPage' },
-  { name: 'Code of Conduct', expectedURL: '/about-us/code-of-conduct', expectedText: 'Welcome to the AboutUsCodeOfConductPage' },
-  { name: 'Donate', expectedURL: '/about-us/donate', expectedText: 'Welcome to the DonatePage' },
-  { name: 'Volunteer', expectedURL: '/about-us/volunteer', expectedText: 'Welcome to the VolunteerPage' },
-  { name: 'Partners', expectedURL: '/about-us/partners', expectedText: 'Welcome to the PartnersPage' },
-  { name: 'Become a Partner', expectedURL: '/about-us/partners/become-a-partner', expectedText: 'Welcome to the BecomeAPartnerPage' },
-  { name: 'Celebrate Her', expectedURL: '/about-us/celebrate-her', expectedText: '#celebrate_her' }
+  {
+    name: 'Overview',
+    expectedURL: '/about-us',
+    expectedText: 'Welcome to the AboutUsPage',
+  },
+  {
+    name: 'Team',
+    expectedURL: '/about-us/team',
+    expectedText: 'Welcome to the TeamPage',
+  },
+  {
+    name: 'Code of Conduct',
+    expectedURL: '/about-us/code-of-conduct',
+    expectedText: 'Welcome to the AboutUsCodeOfConductPage',
+  },
+  {
+    name: 'Donate',
+    expectedURL: '/about-us/donate',
+    expectedText: 'Welcome to the DonatePage',
+  },
+  {
+    name: 'Volunteer',
+    expectedURL: '/about-us/volunteer',
+    expectedText: 'Welcome to the VolunteerPage',
+  },
+  {
+    name: 'Partners',
+    expectedURL: '/about-us/partners',
+    expectedText: 'Welcome to the PartnersPage',
+  },
+  {
+    name: 'Become a Partner',
+    expectedURL: '/about-us/partners/become-a-partner',
+    expectedText: 'Welcome to the BecomeAPartnerPage',
+  },
+  {
+    name: 'Celebrate Her',
+    expectedURL: '/about-us/celebrate-her',
+    expectedText: '#celebrate_her',
+  },
 ];

--- a/src/components/FaqSection.tsx
+++ b/src/components/FaqSection.tsx
@@ -72,8 +72,10 @@ export const FaqSection: React.FC<FaqSectionProps> = ({ title, items }) => {
                   },
                 },
                 '& .MuiAccordionSummary-expandIconWrapper': {
+                  margin: 0,
+                  paddingTop: 0,
+                  paddingBottom: 0,
                   paddingRight: theme.spacing(2),
-                  '& .MuiSvgIcon-root': { fontSize: '40px' },
                 },
               }}
             >

--- a/src/components/FaqSection.tsx
+++ b/src/components/FaqSection.tsx
@@ -43,15 +43,18 @@ export const FaqSection: React.FC<FaqSectionProps> = ({ title, items }) => {
             expanded={expanded === accordionId}
             onChange={handleChange(accordionId)}
             sx={{
+              borderTop: '1px solid',
+              borderColor: '#92908F',
               '&:before': {
                 display: 'none',
               },
-              borderBottom: '1px solid',
-              borderColor: 'divider',
               boxShadow: 'none',
               '&:first-of-type': {
                 borderTop: '1px solid',
                 borderColor: 'divider',
+              },
+              '&.Mui-expanded': {
+                margin: '0',
               },
             }}
           >
@@ -59,9 +62,34 @@ export const FaqSection: React.FC<FaqSectionProps> = ({ title, items }) => {
               expandIcon={<ExpandMoreIcon />}
               aria-controls={`${accordionId}-content`}
               id={`${accordionId}-header`}
-              sx={{ py: 1.25 }}
+              sx={{
+                padding: 0,
+                backgroundColor: theme.palette.custom.softGray,
+                '&.Mui-expanded': {
+                  '& .MuiAccordionSummary-content': {
+                    marginTop: 0,
+                    marginBottom: 0,
+                  },
+                },
+                '& .MuiAccordionSummary-expandIconWrapper': {
+                  paddingRight: theme.spacing(2),
+                  '& .MuiSvgIcon-root': { fontSize: '40px' },
+                },
+              }}
             >
-              <Typography>{item.question}</Typography>
+              <Typography
+                sx={{
+                  py: 1,
+                  px: 2,
+                  fontWeight: 400,
+                  fontSize: '16px',
+                  lineHeight: 1.5,
+                  letterSpacing: '0.5px',
+                  color: theme.palette.text.primary,
+                }}
+              >
+                {item.question}
+              </Typography>
             </AccordionSummary>
             <AccordionDetails>
               <Typography>{item.answer}</Typography>

--- a/src/components/FaqSection.tsx
+++ b/src/components/FaqSection.tsx
@@ -6,24 +6,55 @@ import {
   Box,
   Typography,
 } from '@mui/material';
-import React from 'react';
+import React, { useState, SyntheticEvent } from 'react';
 
 import { FaqSectionProps } from '../utils/types';
 
 export const FaqSection: React.FC<FaqSectionProps> = ({ title, items }) => {
+  const [expanded, setExpanded] = useState<string | false>(false);
+
+  const handleChange =
+    (accordionId: string) => (event: SyntheticEvent, isExpanded: boolean) => {
+      setExpanded(isExpanded ? accordionId : false);
+    };
+
   return (
     <Box sx={{ mb: 4 }}>
       <Typography variant="h5">{title}</Typography>
-      {items.map((item) => (
-        <Accordion key={item.question}>
-          <AccordionSummary expandIcon={<ExpandMoreIcon />}>
-            <Typography>{item.question}</Typography>
-          </AccordionSummary>
-          <AccordionDetails>
-            <Typography>{item.answer}</Typography>
-          </AccordionDetails>
-        </Accordion>
-      ))}
+      {items.map((item, index) => {
+        const accordionId = `accordion-${index}`;
+
+        return (
+          <Accordion
+            key={accordionId}
+            expanded={expanded === accordionId}
+            onChange={handleChange(accordionId)}
+            sx={{
+              '&:before': {
+                display: 'none',
+              },
+              borderBottom: '1px solid',
+              borderColor: 'divider',
+              boxShadow: 'none',
+              '&:first-of-type': {
+                borderTop: '1px solid',
+                borderColor: 'divider',
+              },
+            }}
+          >
+            <AccordionSummary
+              expandIcon={<ExpandMoreIcon />}
+              aria-controls={`${accordionId}-content`}
+              id={`${accordionId}-header`}
+            >
+              <Typography>{item.question}</Typography>
+            </AccordionSummary>
+            <AccordionDetails>
+              <Typography>{item.answer}</Typography>
+            </AccordionDetails>
+          </Accordion>
+        );
+      })}
     </Box>
   );
 };

--- a/src/components/FaqSection.tsx
+++ b/src/components/FaqSection.tsx
@@ -8,6 +8,8 @@ import {
 } from '@mui/material';
 import React, { useState, SyntheticEvent } from 'react';
 
+import theme from 'theme';
+
 import { FaqSectionProps } from '../utils/types';
 
 export const FaqSection: React.FC<FaqSectionProps> = ({ title, items }) => {
@@ -20,7 +22,18 @@ export const FaqSection: React.FC<FaqSectionProps> = ({ title, items }) => {
 
   return (
     <Box sx={{ mb: 4 }}>
-      <Typography variant="h5">{title}</Typography>
+      <Typography
+        variant="h3"
+        component="h2"
+        sx={{
+          mb: 3,
+          fontSize: '45px',
+          lineHeight: 1.156,
+          color: theme.palette.text.primary,
+        }}
+      >
+        {title}
+      </Typography>
       {items.map((item, index) => {
         const accordionId = `accordion-${index}`;
 
@@ -46,6 +59,7 @@ export const FaqSection: React.FC<FaqSectionProps> = ({ title, items }) => {
               expandIcon={<ExpandMoreIcon />}
               aria-controls={`${accordionId}-content`}
               id={`${accordionId}-header`}
+              sx={{ py: 1.25 }}
             >
               <Typography>{item.question}</Typography>
             </AccordionSummary>

--- a/src/components/FaqSection.tsx
+++ b/src/components/FaqSection.tsx
@@ -1,0 +1,18 @@
+import { Box, Typography } from '@mui/material';
+import React from 'react';
+
+import { FaqSectionProps } from '../utils/types';
+
+export const FaqSection: React.FC<FaqSectionProps> = ({ title, items }) => {
+  return (
+    <Box sx={{ mb: 4 }}>
+      <Typography variant="h5">{title}</Typography>
+      {items.map((item) => (
+        <>
+          <p>{item.question}</p>
+          <p>{item.answer}</p>
+        </>
+      ))}
+    </Box>
+  );
+};

--- a/src/components/FaqSection.tsx
+++ b/src/components/FaqSection.tsx
@@ -1,4 +1,11 @@
-import { Box, Typography } from '@mui/material';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import {
+  Accordion,
+  AccordionSummary,
+  AccordionDetails,
+  Box,
+  Typography,
+} from '@mui/material';
 import React from 'react';
 
 import { FaqSectionProps } from '../utils/types';
@@ -8,10 +15,14 @@ export const FaqSection: React.FC<FaqSectionProps> = ({ title, items }) => {
     <Box sx={{ mb: 4 }}>
       <Typography variant="h5">{title}</Typography>
       {items.map((item) => (
-        <>
-          <p>{item.question}</p>
-          <p>{item.answer}</p>
-        </>
+        <Accordion key={item.question}>
+          <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+            <Typography>{item.question}</Typography>
+          </AccordionSummary>
+          <AccordionDetails>
+            <Typography>{item.answer}</Typography>
+          </AccordionDetails>
+        </Accordion>
       ))}
     </Box>
   );

--- a/src/components/__tests__/FaqSection.test.tsx
+++ b/src/components/__tests__/FaqSection.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import React from 'react';
+
+import { FaqSectionProps } from '../../utils/types';
+import { FaqSection } from '../FaqSection';
+
+const mockProps: FaqSectionProps = {
+  title: 'Test mentorship FAQ',
+  items: [
+    {
+      question: 'How do I join the mentorship program?',
+      answer:
+        "You can access comprehensive information about the mentorship program's timelines and registration process by visiting our dedicated mentorship page.",
+    },
+    {
+      question: 'How long does the mentorship program last?',
+      answer:
+        'The Mentorship programme lasts from March till November of the same year.',
+    },
+  ],
+};
+
+const renderComponent = () => render(<FaqSection {...mockProps} />);
+
+const q1 = mockProps.items[0].question;
+const q2 = mockProps.items[1].question;
+const a1 = mockProps.items[0].answer;
+const a2 = mockProps.items[1].answer;
+
+describe('FaqSection - Reusable Component Logic', () => {
+  test('should render section title and all question summaries', () => {
+    renderComponent();
+
+    expect(screen.getByText('Test mentorship FAQ')).toBeInTheDocument();
+    expect(screen.getByText(q1)).toBeInTheDocument();
+    expect(screen.getByText(q2)).toBeInTheDocument();
+  });
+
+  test('should open Q1 and collapse it when Q2 is opened', async () => {
+    renderComponent();
+    const question1 = screen.getByText(q1);
+    const question2 = screen.getByText(q2);
+
+    fireEvent.click(question1);
+    expect(screen.getByText(a1)).toBeVisible();
+
+    fireEvent.click(question2);
+    await waitFor(() => {
+      expect(screen.getByText(a2)).toBeVisible();
+      expect(screen.getByText(a1)).not.toBeVisible();
+    });
+  });
+});

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -9,6 +9,7 @@ import footerData from './responses/footer.json';
 import landingPageData from './responses/landingPage.json';
 import mentors from './responses/mentors.json';
 import mentorShipPage from './responses/mentorship.json';
+import mentorshipFaqPageData from './responses/mentorshipFaqPage.json';
 import ourProgrammesPage from './responses/programmes.json';
 // for new pages: import the json file
 // (which you copied from https://github.com/Women-Coding-Community/wcc-backend/tree/main/src/main/resources)
@@ -21,6 +22,7 @@ const pageData = {
   'about-us/celebrate-her': aboutUsPage,
   'mentorship/mentors': mentors,
   team: aboutUsTeam,
+  'mentorship-faq-page': mentorshipFaqPageData,
 };
 
 export const fetchData = async (path: string) => {

--- a/src/lib/responses/mentorshipFaqPage.json
+++ b/src/lib/responses/mentorshipFaqPage.json
@@ -1,0 +1,93 @@
+{
+  "id": "page:MENTORSHIP_FAQ",
+  "heroSection": {
+    "title": "Mentorship FAQ"
+  },
+  "commonFaqSection": {
+    "title": "Mentors and Mentees FAQ",
+    "items": [
+      {
+        "question": "How do I join the mentorship program?",
+        "answer": "You can access comprehensive information about the mentorship program's timelines and registration process by visiting our dedicated mentorship page."
+      },
+      {
+        "question": "How long does the mentorship program last?",
+        "answer": "The Mentorship programme lasts from March till November of the same year."
+      },
+      {
+        "question": "How often do mentors and mentees meet?",
+        "answer": "The frequency of meetings between mentors and mentees can vary depending on the goals and the needs of the mentee and the availability of both parties. Some relationships require weekly meetings, while others may only require monthly or quarterly meetings."
+      },
+      {
+        "question": "Do I need to be based in London to be a mentor or mentee?",
+        "answer": "No, you can be anywhere in the world, as long as you can work with your mentor or mentee in their timezones."
+      },
+      {
+        "question": "Is this Mentorship Programme available only for remote participation?",
+        "answer": "It is also possible to have meetings in-person if you both are based in the same location. This can be beneficial for people who prefer to have direct personal interactions. In-person mentorship meetings can take place in an office or other location like a cafe, co-working, etc.But only if the mentor and mentee are located in the same city and the mentor is available for an in-person session."
+      },
+      {
+        "question": "What are the benefits of participating in a mentorship programme?",
+        "answer": "Participating in a mentorship programme can provide mentees with access to valuable skills, knowledge, and networks, as well as guidance and support in achieving their goals. Mentors can also benefit from the experience by improving their leadership and mentoring skills, as well as gaining a sense of satisfaction in helping others succeed."
+      },
+      {
+        "question": "What are the goals and objectives of the mentorship programme?",
+        "answer": "The goals and objectives of a mentorship programme may change in light of different needs and circumstances. However, some common goals and objectives include:<br>  1. Professional development: To provide mentees with guidance and support as they navigate their career and personal growth. <br>    2. Skill development: To help mentees develop specific skills and knowledge that will be valuable to them in their current or future roles. <br>  3. Career guidance: To help mentees set and achieve career goals, and to provide them with the tools and resources needed to succeed in their chosen field. <br>  4. Personal development: To provide mentees with guidance and support as they navigate their personal growth and well-being."
+      },
+      {
+        "question": "What do ad-hoc mentorship sessions mean?",
+        "answer": "We made it possible to provide an opportunity for people to schedule one-time mentorship sessions with mentors. Ad-hoc mentorship session is the specific type of mentorship session where the mentor and mentee meet for a single, pre-scheduled session. This session can be in-person or remote, and can be focused on a specific topic or goal."
+      },
+      {
+        "question": "What is Notion?",
+        "answer": "Notion is a productivity and note-taking tool which provides a variety of features to keep track of progress. We recommend using this tool during mentorship experience. Or template can help mentors and mentees be organized and to be on track. At the beginning of the cycle we will conduct a webinar on how to get the most out of Notion note-taking experience."
+      },
+      {
+        "question": "What is the time commitment for participating in this programme?",
+        "answer": "1. Meeting frequency: Mentors and mentees are expected to meet on a regular basis, such as weekly or monthly. It should be discussed between the mentor and mentee during the introduction meeting. <br>   2. Meeting duration: Meetings can be scheduled for different durations, usually lasting between 30 minutes to an hour depending on availability and needs. <br>"
+      },
+      {
+        "question": "What kind of support and resources will be provided to mentors and mentees?",
+        "answer": "For each mentor-mentee pair we provide a template in Notion for tracking the progress during the Mentorship Programme cycle. On the website, you can also find resources and guides which can help mentors and mentees to make the most of their mentorship experience."
+      },
+      {
+        "question": "Who can participate in a mentorship programme?",
+        "answer": "Our mentorship programme is open to anyone who is looking to improve their skills or advance their careers. Whether you’re an experienced professional looking to give back to the community, or a student or new professional seeking guidance and support, our program has something for everyone."
+      }
+    ]
+  },
+  "mentorsFaqSection": {
+    "title": "Mentors FAQ",
+    "items": [
+      {
+        "question": "What is expected of me as a mentor?",
+        "answer": "As a mentor, you will be expected to provide guidance, advice, and support to your mentee as they navigate their professional and personal development. You will be expected to share your own experiences and knowledge, and provide constructive feedback. You will also be expected to help the mentee set and achieve goals, and to introduce them to new opportunities that can help them advance in their career."
+      },
+      {
+        "question": "I haven't mentored before. Could I sign up?",
+        "answer": "Of course, first-time mentors are welcome in the programme! Please take a look at our Mentor’s Pocketbook on Resources Page to help you get started!"
+      },
+      {
+        "question": "I do not identify as a woman, can I participate as a mentor?",
+        "answer": "Absolutely! We are happy to welcome every mentor who is interested in sharing their knowledge with our community."
+      }
+    ]
+  },
+  "menteesFaqSection": {
+    "title": "Mentees FAQ",
+    "items": [
+      {
+        "question": "How can I choose my mentor?",
+        "answer": "Feel free to browse through our Mentors page. Choose a mentor whose goals and aspirations align with yours."
+      },
+      {
+        "question": "What are the expectations for mentees in the mentorship programme?",
+        "answer": "The expectations for mentees may include setting and achieving goals, being open to feedback and guidance, actively seeking out opportunities to learn, and being committed to their own personal and professional growth. Mentees are expected to actively participate in the mentorship relationship, be open to learning and be willing to share their own experiences and knowledge."
+      },
+      {
+        "question": "When do I need a mentor?",
+        "answer": "A mentor can be a valuable resource at different points in your life and career. You may need a mentor when you are starting out in your career, when you are looking to make a career change, when you are facing a specific challenge or obstacle, or when you are looking to advance in your career. A mentor can provide guidance, support, and advice to help you navigate these challenges and achieve your goals."
+      }
+    ]
+  }
+}

--- a/src/pages/mentorship/faqs.tsx
+++ b/src/pages/mentorship/faqs.tsx
@@ -1,6 +1,6 @@
 // path: /mentorship/faqs
 
-import { Typography, Box, Container } from '@mui/material';
+import { Typography, Box, Container, Link } from '@mui/material';
 import { GetServerSideProps } from 'next';
 import { useRouter } from 'next/router';
 import React, { useEffect } from 'react';
@@ -44,27 +44,80 @@ const MentorshipFaqsPage = ({ data, error }: FaqsPageProps) => {
 
   return (
     <>
-      <Box sx={{ ...theme.custom.containerBox, py: 0 }}>
-        <Container maxWidth="md" sx={{ px: theme.spacing(2) }}>
-          <Box sx={{ textAlign: 'center', mb: 5 }}>
-            <Typography variant="h4" component="h1" sx={{ fontWeight: 'bold' }}>
-              {heroSection.title}
+      <Container maxWidth="md">
+        <Box
+          sx={{
+            mb: '15px',
+            textAlign: 'left',
+            marginLeft: { xs: 0, md: theme.spacing(-25) },
+          }}
+        >
+          <Box
+            sx={{
+              fontSize: '14px',
+              lineHeight: 1.4286,
+              fontWeight: 400,
+              letterSpacing: '0.25px',
+              color: theme.palette.text.primary,
+
+              '& a': {
+                color: theme.palette.primary.main,
+                textDecoration: 'none',
+                marginRight: '8px',
+              },
+              '& span': {
+                color: theme.palette.text.primary,
+                marginRight: '8px',
+              },
+            }}
+          >
+            <Link href="/">Home</Link>
+            <Typography component="span">/</Typography>
+            <Link href="/mentorship">Mentorship</Link>
+            <Typography component="span">/</Typography>
+            <Typography component="span" color="inherit">
+              FAQ
             </Typography>
           </Box>
-          <FaqSection
-            title={commonFaqSection.title}
-            items={commonFaqSection.items}
-          />
-          <FaqSection
-            title={mentorsFaqSection.title}
-            items={mentorsFaqSection.items}
-          />
-          <FaqSection
-            title={menteesFaqSection.title}
-            items={menteesFaqSection.items}
-          />
-        </Container>
+        </Box>
+      </Container>
+      <Box
+        sx={{
+          backgroundImage: 'linear-gradient(to right, #9FCEEC, #C7E7FF)',
+          width: '100%',
+        }}
+      >
+        <Box sx={{ textAlign: 'center', py: '48px' }}>
+          <Typography
+            variant="h2"
+            component="h1"
+            sx={{
+              fontFamily: 'Roboto, "Helvetica Neue", Arial, sans-serif',
+              fontSize: '57px',
+              fontWeight: 600,
+              lineHeight: 1.123,
+              letterSpacing: '-0.25px',
+              color: '#001E2E',
+            }}
+          >
+            {heroSection.title}
+          </Typography>
+        </Box>
       </Box>
+      <Container maxWidth="md" sx={{ marginTop: '57px', mb: 8 }}>
+        <FaqSection
+          title={commonFaqSection.title}
+          items={commonFaqSection.items}
+        />
+        <FaqSection
+          title={mentorsFaqSection.title}
+          items={mentorsFaqSection.items}
+        />
+        <FaqSection
+          title={menteesFaqSection.title}
+          items={menteesFaqSection.items}
+        />
+      </Container>
     </>
   );
 };

--- a/src/pages/mentorship/faqs.tsx
+++ b/src/pages/mentorship/faqs.tsx
@@ -5,6 +5,7 @@ import { GetServerSideProps } from 'next';
 import { useRouter } from 'next/router';
 import React, { useEffect } from 'react';
 
+import { fetchData } from 'lib/api';
 import theme from 'theme';
 
 import { FaqSection } from '../../components/FaqSection';
@@ -71,10 +72,22 @@ const MentorshipFaqsPage = ({ data, error }: FaqsPageProps) => {
 export default MentorshipFaqsPage;
 
 export const getServerSideProps: GetServerSideProps = async () => {
-  return {
-    props: {
-      data: null,
-      error: null,
-    },
-  };
+  try {
+    const combinedResponse = await fetchData('mentorship-faq-page');
+    const data: MentorshipPageData = combinedResponse.data;
+
+    return {
+      props: {
+        data: data,
+        error: null,
+      },
+    };
+  } catch (error) {
+    return {
+      props: {
+        data: null,
+        error: error instanceof Error ? error.message : 'An error occurred',
+      },
+    };
+  }
 };

--- a/src/pages/mentorship/faqs.tsx
+++ b/src/pages/mentorship/faqs.tsx
@@ -1,13 +1,80 @@
 // path: /mentorship/faqs
 
-import { Typography } from '@mui/material';
+import { Typography, Box, Container } from '@mui/material';
+import { GetServerSideProps } from 'next';
+import { useRouter } from 'next/router';
+import React, { useEffect } from 'react';
 
-const MentorshipFaqsPage = () => {
+import theme from 'theme';
+
+import { FaqSection } from '../../components/FaqSection';
+import { MentorshipPageData } from '../../utils/types';
+
+interface FaqsPageProps {
+  data: MentorshipPageData | null;
+  error: string | null;
+}
+
+const MentorshipFaqsPage = ({ data, error }: FaqsPageProps) => {
+  const router = useRouter();
+
+  useEffect(() => {
+    if (error) {
+      router.push('/500');
+    }
+  }, [error, router]);
+
+  if (!data) {
+    return (
+      <Container maxWidth="md" sx={{ mt: 4, mb: 8 }}>
+        <Typography variant="h6" color="error">
+          An error occurred while loading the FAQ page.
+        </Typography>
+      </Container>
+    );
+  }
+
+  const {
+    heroSection,
+    commonFaqSection,
+    mentorsFaqSection,
+    menteesFaqSection,
+  } = data;
+
   return (
-    <div>
-      <Typography variant="h4">Welcome to the MentorshipFaqsPage</Typography>
-    </div>
+    <>
+      <Box sx={{ ...theme.custom.containerBox, py: 0 }}>
+        <Container maxWidth="md" sx={{ px: theme.spacing(2) }}>
+          <Box sx={{ textAlign: 'center', mb: 5 }}>
+            <Typography variant="h4" component="h1" sx={{ fontWeight: 'bold' }}>
+              {heroSection.title}
+            </Typography>
+          </Box>
+          <FaqSection
+            title={commonFaqSection.title}
+            items={commonFaqSection.items}
+          />
+          <FaqSection
+            title={mentorsFaqSection.title}
+            items={mentorsFaqSection.items}
+          />
+          <FaqSection
+            title={menteesFaqSection.title}
+            items={menteesFaqSection.items}
+          />
+        </Container>
+      </Box>
+    </>
   );
 };
 
 export default MentorshipFaqsPage;
+
+export const getServerSideProps: GetServerSideProps = async () => {
+  return {
+    props: {
+      data: null,
+      error: null,
+    },
+  };
+};

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -272,3 +272,30 @@ export type Mentor = {
     link?: Link;
   }[];
 };
+
+export interface FaqHeroSection {
+  title: string;
+}
+
+export interface FAQItem {
+  question: string;
+  answer: string;
+}
+
+export interface FAQContentSection {
+  title: string;
+  items: FAQItem[];
+}
+
+export interface MentorshipPageData {
+  id: string;
+  heroSection: FaqHeroSection;
+  commonFaqSection: FAQContentSection;
+  mentorsFaqSection: FAQContentSection;
+  menteesFaqSection: FAQContentSection;
+}
+
+export interface FaqSectionProps {
+  title: string;
+  items: FAQItem[];
+}


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
### This PR implements the Mentorship FAQ Page and is based on the following core approach:

- Create a reusable "FAQ Section" component (FaqSection.tsx) that handles the single-open, border/shadow styling, and accordion logic.
- Use this reusable component on the Mentorship FAQ page to show the specific common, mentor, and mentee FAQs.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Type

- [ ] Bug Fix
- [x] New Feature
- [ ] Code Refactor
- [ ] Documentation
- [ ] Other

## Related Issue
Fixes Issue #75
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Screenshots
<img width="1006" height="1306" alt="image" src="https://github.com/user-attachments/assets/aefaa3b6-f25f-421a-8224-64d02b015e76" />

<!--  If you are adding or changing a component or page, styling it is mandatory to add a screenshot of your work. -->
<!-- If your component is not visible at the current time of the application (e.g. creating a reusable component before using it), add a screenshot how it would look like per the design and when you used it in your local development >
<!--  Please add screenshot from *before* and *after* to simply the code review -->

## Testing
Unit tests cover component logic, successfully verifying single-open behavior in FaqSection.test.tsx.
<!--  On component level: Ensure you have a unit test in place. -->
<!--  WILL BE IMPLEMENTED LATER: -->
<!--  On page level: Ensure you have added/updated the integration tests. -->

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] I checked and followed the [contributor guide](../CONTRIBUTING.md)
- [x] I have tested my changes locally.
- [x] I have added a screenshot from the website after I tested it locally

<!--  Thanks for sending a pull request! -->
