### PR TITLE
fix(footer): correct email icon link to open mail client instead of 404

### DIFF
--- a/src/lib/responses/aboutUsTeam.json
+++ b/src/lib/responses/aboutUsTeam.json
@@ -11,7 +11,7 @@
     "links": [
       {
         "type": "email",
-        "link": "london@womencodingcommunity.com"
+        "link": "mailto:london@womencodingcommunity.com"
       },
       {
         "type": "slack",

--- a/src/lib/responses/footer.json
+++ b/src/lib/responses/footer.json
@@ -22,7 +22,7 @@
     },
     {
       "type": "email",
-      "link": "london@womencodingcommunity.com"
+      "link": "mailto:london@womencodingcommunity.com"
     },
     {
       "type": "slack",


### PR DESCRIPTION
## Description

Fixed a missing word in the JSON files email to redirect to the email rather than a 404 page.

## Type

- [x] Bug Fix
- [ ] New Feature
- [ ] Code Refactor
- [ ] Documentation
- [ ] Other

## Related Issue

[Bug: Footer “Email” (envelope) icon opens 404 instead of email client #161](https://github.com/Women-Coding-Community/wcc-frontend/issues/161)

## Screenshots

<img width="1487" height="802" alt="Screenshot 2025-11-16 152711" src="https://github.com/user-attachments/assets/25397aba-c77a-4f5d-ab53-af74aba1cb7d" />

## Testing

<!--  On component level: Ensure you have a unit test in place. -->
<!--  WILL BE IMPLEMENTED LATER: -->
<!--  On page level: Ensure you have added/updated the integration tests. -->

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ x ] I checked and followed the [contributor guide](../CONTRIBUTING.md)
- [ x ] I have tested my changes locally.
- [ x ] I have added a screenshot from the website after I tested it locally

<!--  Thanks for sending a pull request! -->
