### PR TITLE
Removed Twitter icon and link from footer

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -2,7 +2,6 @@ import EmailIcon from '@mui/icons-material/Email';
 import GitHubIcon from '@mui/icons-material/GitHub';
 import InstagramIcon from '@mui/icons-material/Instagram';
 import LinkedInIcon from '@mui/icons-material/LinkedIn';
-import TwitterIcon from '@mui/icons-material/Twitter';
 import { Box, Typography, Link, Icon, useMediaQuery } from '@mui/material';
 import Image from 'next/image';
 import React from 'react';
@@ -18,7 +17,6 @@ const iconNetworkMapper = {
   linkedin: <LinkedInIcon fontSize="large" />,
   github: <GitHubIcon fontSize="large" />,
   instagram: <InstagramIcon fontSize="large" />,
-  twitter: <TwitterIcon fontSize="large" />,
   email: <EmailIcon fontSize="large" />,
   slack: <SlackIcon width={32} height={32} fill={'FFF'} />,
 };

--- a/src/lib/responses/footer.json
+++ b/src/lib/responses/footer.json
@@ -5,12 +5,8 @@
   "description": "Women Coding Community is a not-for-profit organisation. © 2024 Women Coding Community",
   "network": [
     {
-      "type": "linkedIn",
+      "type": "linkedin",
       "link": "https://www.linkedin.com/company/womencodingcommunity"
-    },
-    {
-      "type": "twitter",
-      "link": "https://twitter.com/WCC_Community"
     },
     {
       "type": "github",


### PR DESCRIPTION
## Description

Removed Twitter icon and link from footer
This change is required as Twitter is no longer used by WCC community.

## Type

- [ ] Bug Fix
- [ ] New Feature
- [ ] Code Refactor
- [ ] Documentation
- [X] Other - Clean up

## Related Issue

#180 

## Screenshots

Before:
<img width="1920" height="1020" alt="image" src="https://github.com/user-attachments/assets/6ebd3092-fd77-409e-b77b-601014b30331" />

After:
<img width="1920" height="1020" alt="image" src="https://github.com/user-attachments/assets/8df72f7a-5e3a-4f7c-82ec-e1bfddb0d21a" />


## Testing

- [X] Tested locally by running npm run dev and verifying the mentorship page at http://localhost:3000/mentorship 

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [X] I checked and followed the [contributor guide](../CONTRIBUTING.md)
- [X] I have tested my changes locally.
- [X] I have added a screenshot from the website after I tested it locally

<!--  Thanks for sending a pull request! -->
