### PR TITLE
#221 fix: 404 page not found design

### DIFF
--- a/src/components/ErrorPageComponent.tsx
+++ b/src/components/ErrorPageComponent.tsx
@@ -18,17 +18,22 @@ export const ErrorPageComponent: React.FC<ErrorProps> = ({ title }) => {
       }}
     >
       <main>
-        <Typography variant="h3" color="#001E2E" sx={{ marginBottom: '20px' }}>
+        <Typography variant="h3" color="#001E2E" sx={{ marginBottom: "20px" }}>
           {title}
         </Typography>
 
         <Image
           src="/icons/error-illustration.png"
           alt="Error Robot"
-          width="100"
-          height="100"
+          width={743}
+          height={418}
+          sizes="100vw"
+          style={{
+            width: "100%",
+            height: "auto",
+          }}
         />
-        <Typography variant="body1">
+        <Typography variant="body1" sx={{ marginTop: "30px", marginBottom: "20px" }}>
           Something went wrong on our end. Please try again later.
         </Typography>
         <Button
@@ -36,7 +41,7 @@ export const ErrorPageComponent: React.FC<ErrorProps> = ({ title }) => {
           href="/"
           variant="contained"
           color="primary"
-          sx={{ borderRadius: '100px' }}
+          sx={{ borderRadius: "100px", marginBottom:"20px" }}
         >
           Back to home
         </Button>


### PR DESCRIPTION
## Description
Changed the styling of the page by updating image size and adding spacing. Also updated the mobile view to make sure the image size fit smaller screen sizes.
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Type

- [X] Bug Fix
- [ ] New Feature
- [ ] Code Refactor
- [ ] Documentation
- [ ] Other

## Related Issue
#221 

## Screenshots
Desktop view
<img width="1917" height="909" alt="1 fixed 404 page layout - desktop" src="https://github.com/user-attachments/assets/19fa8bdb-f26c-4a68-ae1d-4a7646281c02" />

Mobile view
<img width="383" height="787" alt="1 fixed 404 page layout - mobile" src="https://github.com/user-attachments/assets/fd6b5415-1860-4d47-a2f5-a7d7bb9c425a" />

<!--  If you are adding or changing a component or page, styling it is mandatory to add a screenshot of your work. -->
<!-- If your component is not visible at the current time of the application (e.g. creating a reusable component before using it), add a screenshot how it would look like per the design and when you used it in your local development >
<!--  Please add screenshot from *before* and *after* to simply the code review -->

<!--## Testing-->

<!--  On component level: Ensure you have a unit test in place. -->
<!--  WILL BE IMPLEMENTED LATER: -->
<!--  On page level: Ensure you have added/updated the integration tests. -->

<!--
If E2E visual tests fail due to screenshot differences and the UI has been changed intentionally, update the reference screenshots by running:

pnpm test:e2e:docker:update

Verify the updated snapshots and commit them as part of this PR.
-->

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] I checked and followed the [contributor guide](../CONTRIBUTING.md)
- [x] I have tested my changes locally.
- [x] I have added a screenshot from the website after I tested it locally

<!--  Thanks for sending a pull request! -->
