### PR TITLE
fix: Button style on Hero

### DIFF
--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,8 +1,8 @@
-import { Box, Typography, Grid, useMediaQuery, Link } from '@mui/material';
+import { Box, Typography, Grid, useMediaQuery } from '@mui/material';
 import Image from 'next/image';
 import React from 'react';
 
-import { GradientBorderDivider } from '@components';
+import { GradientBorderDivider, LinkButton } from '@components';
 
 import theme from '../theme';
 import { LandingPageResponse } from '../utils/types';
@@ -60,21 +60,12 @@ export const Hero: React.FC<HeroProps> = ({ title, subtitle, images }) => {
             >
               {subtitle}
             </Typography>
-            <Link
+            <LinkButton
               href="https://join.slack.com/t/womencodingcommunity/shared_invite/zt-2hpjwpx7l-rgceYBIWp6pCiwc0hVsX8A"
-              target="_blank"
-              rel="noopener noreferrer"
-              sx={{
-                fontSize: '1.25rem',
-                textDecoration: 'underline',
-                color: 'theme.palette.primary.main',
-                '&:hover': {
-                  textDecoration: 'none',
-                },
-              }}
+              outlined
             >
               Join our Slack
-            </Link>
+            </LinkButton>
           </Box>
         </Grid>
         <Grid item xs={12} sm={7} style={{ padding: 0, margin: 0 }}>

--- a/src/components/LinkButton.tsx
+++ b/src/components/LinkButton.tsx
@@ -1,21 +1,70 @@
-import { Button } from '@mui/material';
+import { Button, type SxProps, type Theme } from '@mui/material';
 import Link from 'next/link';
 import React from 'react';
 
 type LinkButtonProps = {
   href: string;
   reversed?: boolean;
+  outlined?: boolean;
   small?: boolean;
   children: React.ReactNode;
 };
 
+const pillRadius = '100px';
+
 export const LinkButton = ({
   href,
   reversed,
+  outlined,
   small,
   children,
 }: LinkButtonProps) => {
   const isExternal = href.startsWith('https');
+
+  const padding = small ? '7px 16px' : '10px 32px';
+
+  if (outlined) {
+    const outlinedPadding = small ? '7px 16px' : '10px 24px';
+    const outlinedSx: SxProps<Theme> = (theme) => ({
+      ...(small
+        ? theme.typography.outlineButtonSmall
+        : theme.typography.outlineButton),
+      borderRadius: pillRadius,
+      padding: outlinedPadding,
+      minHeight: small ? undefined : '40px',
+      borderColor: theme.palette.custom.outline,
+      color: 'primary.main',
+      boxShadow: 'none',
+      '&:hover': {
+        borderColor: theme.palette.custom.outline,
+        backgroundColor: 'primary.light',
+        boxShadow: 'none',
+      },
+    });
+
+    if (isExternal) {
+      return (
+        <Button
+          component="a"
+          href={href}
+          target="_blank"
+          rel="noopener noreferrer"
+          variant="outlined"
+          sx={outlinedSx}
+        >
+          {children}
+        </Button>
+      );
+    }
+
+    return (
+      <Link href={href} passHref legacyBehavior>
+        <Button component="a" variant="outlined" sx={outlinedSx}>
+          {children}
+        </Button>
+      </Link>
+    );
+  }
 
   if (isExternal) {
     return (
@@ -25,15 +74,15 @@ export const LinkButton = ({
         target="_blank"
         rel="noopener noreferrer"
         variant="contained"
-        sx={{
+        sx={(theme) => ({
+          ...(small
+            ? theme.typography.linkButtonContainedSmall
+            : theme.typography.linkButtonContained),
           backgroundColor: reversed ? '#fff' : 'primary.main',
           color: reversed ? 'primary.main' : '#fff',
-          borderRadius: '100px',
-          textTransform: 'none',
-          fontWeight: 600,
-          fontSize: '1rem',
-          padding: '10px 32px',
-        }}
+          borderRadius: pillRadius,
+          padding,
+        })}
       >
         {children}
       </Button>
@@ -45,16 +94,15 @@ export const LinkButton = ({
       <Button
         component="a"
         variant="contained"
-        sx={{
+        sx={(theme) => ({
+          ...(small
+            ? theme.typography.linkButtonContainedSmall
+            : theme.typography.linkButtonContained),
           backgroundColor: reversed ? '#fff' : 'primary.main',
           color: reversed ? 'primary.main' : '#fff',
-          borderRadius: '100px',
-          textTransform: 'none',
-          fontWeight: 600,
-          // width: small ? 'fit-content' : '100%',
-          fontSize: small ? '0.8rem' : '1rem',
-          padding: small ? '7px 16px' : '10px 32px',
-        }}
+          borderRadius: pillRadius,
+          padding,
+        })}
       >
         {children}
       </Button>

--- a/src/components/__tests__/LinkButton.test.tsx
+++ b/src/components/__tests__/LinkButton.test.tsx
@@ -1,11 +1,17 @@
+import { ThemeProvider } from '@mui/material';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 
+import theme from 'theme';
+
 import { LinkButton } from '../LinkButton';
+
+const renderWithTheme = (ui: React.ReactElement) =>
+  render(<ThemeProvider theme={theme}>{ui}</ThemeProvider>);
 
 describe('LinkButton', () => {
   it('renders an internal link using Next.js Link', () => {
-    render(<LinkButton href="/internal">Internal Link</LinkButton>);
+    renderWithTheme(<LinkButton href="/internal">Internal Link</LinkButton>);
     const button = screen.getByRole('link', { name: /internal link/i });
     expect(button).toBeInTheDocument();
     expect(button.closest('a')).toHaveAttribute('href', '/internal');
@@ -21,5 +27,16 @@ describe('LinkButton', () => {
     // opens external links in a new tab
     expect(button.closest('a')).toHaveAttribute('target', '_blank');
     expect(button.closest('a')).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+
+  it('renders an outlined external link', () => {
+    renderWithTheme(
+      <LinkButton href="https://external.com" outlined>
+        Outlined External
+      </LinkButton>,
+    );
+    const link = screen.getByRole('link', { name: /outlined external/i });
+    expect(link).toBeInTheDocument();
+    expect(link.closest('a')).toHaveAttribute('href', 'https://external.com');
   });
 });

--- a/src/pages/mentorship/index.tsx
+++ b/src/pages/mentorship/index.tsx
@@ -165,11 +165,11 @@ const FeedbackSection: React.FC<FeedbackSectionProps> = ({
             }
             variant="outlined"
             data-testid="feedback-show-more"
-            sx={{
+            sx={(t) => ({
               borderRadius: '20px',
-              border: '1px solid #71787E',
-              color: '#1A4B66',
-            }}
+              border: `1px solid ${t.palette.custom.outline}`,
+              color: t.palette.custom.linkBlue,
+            })}
           >
             {feedbacksDisplayed >= feedbacks.length
               ? '- Show less'

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -2,6 +2,7 @@
 /* eslint-disable unused-imports/no-unused-vars */
 
 import { createTheme } from '@mui/material/styles';
+import type { CSSProperties } from 'react';
 
 const COLORS = {
   lightBlue: '#C7E7FF',
@@ -9,6 +10,7 @@ const COLORS = {
   lightPink: '#FFDBD0',
   softGray: '#F4F0EF',
   linkBlue: '#1A4B66',
+  outline: '#71787E',
 } as const;
 
 declare module '@mui/material/styles' {
@@ -84,6 +86,7 @@ declare module '@mui/material/styles' {
       lightOrange: string;
       studyGroupCardColors: string[];
       linkBlue: string;
+      outline: string;
     };
   }
   interface PaletteOptions {
@@ -93,7 +96,31 @@ declare module '@mui/material/styles' {
       lightOrange?: string;
       studyGroupCardColors?: string[];
       linkBlue?: string;
+      outline?: string;
     };
+  }
+
+  interface TypographyVariants {
+    outlineButton: CSSProperties;
+    outlineButtonSmall: CSSProperties;
+    linkButtonContained: CSSProperties;
+    linkButtonContainedSmall: CSSProperties;
+  }
+
+  interface TypographyVariantsOptions {
+    outlineButton?: CSSProperties;
+    outlineButtonSmall?: CSSProperties;
+    linkButtonContained?: CSSProperties;
+    linkButtonContainedSmall?: CSSProperties;
+  }
+}
+
+declare module '@mui/material/Typography' {
+  interface TypographyPropsVariantOverrides {
+    outlineButton: true;
+    outlineButtonSmall: true;
+    linkButtonContained: true;
+    linkButtonContainedSmall: true;
   }
 }
 
@@ -204,6 +231,33 @@ const theme = createTheme({
       lineHeight: 1.2,
     },
 
+    outlineButton: {
+      fontFamily: '"Roboto", "Helvetica", "Arial", sans-serif',
+      fontWeight: 500,
+      fontSize: '0.875rem',
+      lineHeight: '20px',
+      letterSpacing: '0.1px',
+      textTransform: 'none',
+    },
+    outlineButtonSmall: {
+      fontFamily: '"Roboto", "Helvetica", "Arial", sans-serif',
+      fontWeight: 500,
+      fontSize: '0.8rem',
+      lineHeight: '20px',
+      letterSpacing: '0.1px',
+      textTransform: 'none',
+    },
+    linkButtonContained: {
+      fontWeight: 600,
+      fontSize: '1rem',
+      textTransform: 'none',
+    },
+    linkButtonContainedSmall: {
+      fontWeight: 600,
+      fontSize: '0.8rem',
+      textTransform: 'none',
+    },
+
     fontWeightBold: 600,
     fontWeightMedium: 400,
   },
@@ -228,6 +282,7 @@ const theme = createTheme({
         COLORS.softGray,
       ],
       linkBlue: COLORS.linkBlue,
+      outline: COLORS.outline,
     },
     text: {
       primary: '#1b1919',


### PR DESCRIPTION
## Description

Updates the home page hero **“Join our Slack”** control from a plain underlined `Link` to the shared **`LinkButton`** component with an **outlined** style so it matches design: pill shape, **M3 outline** border (`#71787E`), primary label colour, no underline, and label typography aligned with Figma (14px / medium weight / line-height / letter-spacing).

**`LinkButton`**

- New optional **`outlined`** prop: MUI `variant="outlined"`, same **external (`https`) vs internal** behaviour as before (`<a target="_blank">` vs Next `Link`).
- Typography for outlined and contained variants is driven by **`theme.typography`** instead of hard-coded font rules in the component.
- Layout details (padding, min-height for outlined) stay in the component; border colour uses **`theme.palette.custom.outline`**.

**`theme.ts`**

- Adds **`palette.custom.outline`** (`#71787E`, M3 sys/light/outline).
- Adds typography variants: **`outlineButton`**, **`outlineButtonSmall`**, **`linkButtonContained`**, **`linkButtonContainedSmall`**.

**Other**

- **`LinkButton` unit tests**: wrapped with **`ThemeProvider`** so theme tokens resolve.

## Type

- [x] Bug Fix
- [ ] New Feature
- [x] Code Refactor
- [ ] Documentation
- [ ] Other

## Related Issue

[<!-- e.g. Fixes #217 — add your issue link -->](https://github.com/Women-Coding-Community/wcc-frontend/issues/217)

## Screenshots

before:
<img width="451" height="374" alt="image" src="https://github.com/user-attachments/assets/11fb74ac-6b0b-49d2-a593-e6fbea76913c" />

Now:
<img width="733" height="616" alt="image" src="https://github.com/user-attachments/assets/ebb00e9d-3a77-4096-beec-adff14bf119c" />

## Testing

- **Unit:** `pnpm test -- LinkButton.test`
- **Manual:** Home hero — “Join our Slack” is an outlined pill; link opens Slack in a new tab.
- **Note:** Full `pnpm test` may show unrelated failures (e.g. mentee registration test timeout).

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] I checked and followed the [contributor guide](../CONTRIBUTING.md)
- [x] I have tested my changes locally.
- [x] I have added a screenshot from the website after I tested it locally