### PR TITLE
fix: update footer link styles and text to match Figma #218

### DIFF
--- a/playwright-tests/pages/base.page.ts
+++ b/playwright-tests/pages/base.page.ts
@@ -60,7 +60,7 @@ export class BasePage {
       Instagram: links.filter({ has: page.getByTestId('InstagramIcon') }),
       Email: links.filter({ has: page.getByTestId('EmailIcon') }),
       Slack: page.locator('a[href*="join.slack.com"]').last(),
-      'Send us a report': page.getByText('Send us a report', { exact: true }),
+      'Send us a report': page.getByText('Send us a report on GitHub', { exact: true }),
     };
   }
 

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -130,19 +130,22 @@ export const Footer = ({
           </Box>
           <Typography
             variant="body1"
-            sx={{ 
-              fontSize: '16px', 
+            sx={{
+              fontSize: '16px',
               fontWeight: 500,
-              color: '#000000', 
-              pt: 2 
+              color: '#000000',
+              pt: 2,
             }}
           >
-            {link?.title || "Experiencing Technical Issues?"} <br />
+            {link?.title || 'Experiencing Technical Issues?'} <br />
             <Link
-              href={link?.uri || "https://github.com/Women-Coding-Community/wcc-website/issues"}
+              href={
+                link?.uri ||
+                'https://github.com/Women-Coding-Community/wcc-website/issues'
+              }
               target="_blank"
               rel="noopener noreferrer"
-              sx={{ 
+              sx={{
                 color: 'custom.linkBlue',
                 fontSize: '14px',
                 fontWeight: 400,
@@ -150,7 +153,7 @@ export const Footer = ({
               }}
             >
               {/* Hardcoded to match Figma #218 and override incomplete BE label */}
-                Send us a report on GitHub
+              Send us a report on GitHub
             </Link>
           </Typography>
         </Box>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -130,20 +130,27 @@ export const Footer = ({
           </Box>
           <Typography
             variant="body1"
-            color="primary.dark"
-            typography={{ fontWeight: '600' }}
-            pt={2}
-            sx={{ fontSize: '16px' }}
+            sx={{ 
+              fontSize: '16px', 
+              fontWeight: 500,
+              color: '#000000', 
+              pt: 2 
+            }}
           >
-            {link.title} <br />
+            {link?.title || "Experiencing Technical Issues?"} <br />
             <Link
-              href={link.uri}
-              color="primary.dark"
+              href={link?.uri || "https://github.com/Women-Coding-Community/wcc-website/issues"}
               target="_blank"
               rel="noopener noreferrer"
-              typography={{ fontWeight: '500' }}
+              sx={{ 
+                color: 'custom.linkBlue',
+                fontSize: '14px',
+                fontWeight: 400,
+                textDecoration: 'underline',
+              }}
             >
-              {link.label}
+              {/* Hardcoded to match Figma #218 and override incomplete BE label */}
+                Send us a report on GitHub
             </Link>
           </Typography>
         </Box>


### PR DESCRIPTION
## Description
## fix: Footer button style #218
<!--- Describe your changes in detail -->
- Updated footer link typography to match Figma (14px, Weight 400).
- Updated title weight to 500 and color to #000000.
- Hardcoded the label "Send us a report on GitHub" to ensure design consistency and override incomplete backend data.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Closes #218
## Type

- [ ] Bug Fix
- [ ] New Feature
- [ ] Code Refactor
- [ ] Documentation
- [x] Style/UI

## Related Issue

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Screenshots
<img width="422" height="235" alt="image" src="https://github.com/user-attachments/assets/c008255d-d998-4281-be38-76af5899a134" />

<!--  If you are adding or changing a component or page, styling it is mandatory to add a screenshot of your work. -->
<!-- If your component is not visible at the current time of the application (e.g. creating a reusable component before using it), add a screenshot how it would look like per the design and when you used it in your local development >
<!--  Please add screenshot from *before* and *after* to simply the code review -->

## Testing

<!--  On component level: Ensure you have a unit test in place. -->
<!--  WILL BE IMPLEMENTED LATER: -->
<!--  On page level: Ensure you have added/updated the integration tests. -->

<!--
If E2E visual tests fail due to screenshot differences and the UI has been changed intentionally, update the reference screenshots by running:

pnpm test:e2e:docker:update

Verify the updated snapshots and commit them as part of this PR.
-->

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] I checked and followed the [contributor guide](../CONTRIBUTING.md)
- [x] I have tested my changes locally.
- [x] I have added a screenshot from the website after I tested it locally

<!--  Thanks for sending a pull request! -->
