### PR TITLE
fix: standardise breadcrumbs across mentorship pages (#201)

### DIFF
--- a/playwright-tests/tests/home.page.spec.ts
+++ b/playwright-tests/tests/home.page.spec.ts
@@ -89,9 +89,7 @@ test.describe('Validate Home Page', () => {
     await basePage.clickElement(homePage.joinAsMentorBtn);
 
     await basePage.verifyURL('/mentorship/mentor-registration');
-    await basePage.verifyPageContainsText(
-      'Welcome to the MentorRegistrationPage',
-    );
+    await basePage.verifyPageContainsText('WCC: Registration Form for Mentors');
   });
 
   test('HP-004: Volunteer section', async ({ homePage, basePage }) => {

--- a/src/__tests__/pages/MenteeRegistrationPage.test.tsx
+++ b/src/__tests__/pages/MenteeRegistrationPage.test.tsx
@@ -19,7 +19,11 @@ jest.mock('next/link', () => {
 });
 
 jest.mock('next/router', () => ({
-  useRouter: () => ({ push: jest.fn(), pathname: '/' }),
+  useRouter: () => ({
+    push: jest.fn(),
+    pathname: '/mentorship/mentee-registration',
+    query: {},
+  }),
 }));
 
 // Mutable flag so individual tests can override the registration state

--- a/src/components/BreadCrumbsDynamic.tsx
+++ b/src/components/BreadCrumbsDynamic.tsx
@@ -18,6 +18,7 @@ export const BreadCrumbsDynamic = () => {
         margin: 0,
         width: '100%',
         mx: 'auto',
+        px: 2,
         boxSizing: 'border-box',
         maxWidth: '1128px',
       }}

--- a/src/pages/mentorship/ad-hoc-timeline.tsx
+++ b/src/pages/mentorship/ad-hoc-timeline.tsx
@@ -26,7 +26,7 @@ const MentorshipAdHocTimelinePage = ({ data, footer }: CombinedResponse) => {
 
   return (
     <>
-      {isMobile ? null : <BreadCrumbsDynamic />}
+      <BreadCrumbsDynamic />
       <Title title={'Ad-Hoc Mentorship Timeline'} />
       <Box sx={theme.custom.containerBox}>
         <Timeline position="right">

--- a/src/pages/mentorship/code-of-conduct.tsx
+++ b/src/pages/mentorship/code-of-conduct.tsx
@@ -4,7 +4,6 @@ import { Box, Typography } from '@mui/material';
 import { GetServerSideProps } from 'next';
 
 import { BreadCrumbsDynamic, CodeOfConductSection } from '@components';
-import { useIsMobile } from '@utils/theme-utils';
 import { MentorshipCodeOfConductData } from '@utils/types';
 import { fetchData } from 'lib/api';
 
@@ -15,10 +14,9 @@ interface AboutUsCodeOfConductPageProps {
 const MentorshipCodeOfConductPage = ({
   mentorshipCodeOfConduct,
 }: AboutUsCodeOfConductPageProps) => {
-  const isMobile = useIsMobile();
   return (
     <>
-      {isMobile ? null : <BreadCrumbsDynamic />}
+      <BreadCrumbsDynamic />
       <Box
         sx={{
           display: 'flex',

--- a/src/pages/mentorship/faqs.tsx
+++ b/src/pages/mentorship/faqs.tsx
@@ -3,7 +3,6 @@ import { GetServerSideProps } from 'next';
 import React from 'react';
 
 import { BreadCrumbsDynamic, FaqSection } from '@components';
-import { useIsMobile } from '@utils/theme-utils';
 import { fetchData } from 'lib/api';
 
 import { MentorshipPageData } from '../../utils/types';
@@ -21,11 +20,10 @@ const MentorshipFaqsPage = ({ data }: FaqsPageProps) => {
   } = data;
 
   const faqSections = [commonFaqSection, mentorsFaqSection, menteesFaqSection];
-  const isMobile = useIsMobile();
 
   return (
     <>
-      {isMobile ? <BreadCrumbsDynamic /> : null}
+      <BreadCrumbsDynamic />
       <Box
         sx={{
           backgroundImage: 'linear-gradient(to right, #9FCEEC, #C7E7FF)',

--- a/src/pages/mentorship/index.tsx
+++ b/src/pages/mentorship/index.tsx
@@ -10,7 +10,6 @@ import {
   MentorBecomeCard,
   Title,
 } from '@components';
-import { useIsMobile } from '@utils/theme-utils';
 import {
   FooterResponse,
   MentorshipProgrammeData,
@@ -30,10 +29,9 @@ interface FeedbackSectionProps {
   feedbacks: FeedbackItem[];
 }
 const MentorshipPage = ({ mentorship, footer }: MentorshipPageProps) => {
-  const isMobile = useIsMobile();
   return (
     <>
-      {isMobile ? null : <BreadCrumbsDynamic />}
+      <BreadCrumbsDynamic />
       <Title title={mentorship.heroSection.title} />
 
       <Box

--- a/src/pages/mentorship/long-term-timeline.tsx
+++ b/src/pages/mentorship/long-term-timeline.tsx
@@ -24,7 +24,7 @@ const MentorshipLongTermTimelinePage = ({ data, footer }: CombinedResponse) => {
   const isMobile = useIsMobile();
   return (
     <>
-      {isMobile ? null : <BreadCrumbsDynamic />}
+      <BreadCrumbsDynamic />
       <Title title={'Long-Term Mentorship Timeline'} />
       <Box sx={theme.custom.containerBox}>
         <Timeline position="right">

--- a/src/pages/mentorship/mentee-registration.tsx
+++ b/src/pages/mentorship/mentee-registration.tsx
@@ -2,10 +2,8 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import {
   Alert,
   Box,
-  Breadcrumbs,
   Button,
   Container,
-  Link,
   Paper,
   Stack,
   Typography,
@@ -16,6 +14,7 @@ import NextLink from 'next/link';
 import React, { useEffect, useState } from 'react';
 import { FormProvider, UseFormReturn, useForm } from 'react-hook-form';
 
+import { BreadCrumbsDynamic } from '@components';
 import {
   menteeFormDefaultValues,
   menteeFormSchema,
@@ -175,24 +174,7 @@ const MenteeRegistrationPage = () => {
 
   return (
     <>
-      <Box
-        sx={{
-          backgroundColor: 'white',
-          py: 2,
-          px: { xs: 2, sm: 3, md: '157px' },
-        }}
-      >
-        <Breadcrumbs>
-          <Link href="/" color="primary" underline="always">
-            Home
-          </Link>
-          <Link href="/mentorship" color="primary" underline="always">
-            Mentorship
-          </Link>
-          <Typography color="text.primary">Mentee Registration</Typography>
-        </Breadcrumbs>
-      </Box>
-
+      <BreadCrumbsDynamic />
       <FormProvider {...formMethods}>
         <Box
           sx={{

--- a/src/pages/mentorship/mentor-registration.tsx
+++ b/src/pages/mentorship/mentor-registration.tsx
@@ -15,6 +15,7 @@ import Link from 'next/link';
 import React, { useState } from 'react';
 import { useForm, FormProvider, type Resolver } from 'react-hook-form';
 
+import { BreadCrumbsDynamic } from '@components';
 import Step1BasicInfo from 'components/mentorship/Step1BasicInfo';
 import Step2Skills from 'components/mentorship/Step2Skills';
 import Step3DomainSkills from 'components/mentorship/Step3DomainSkills';
@@ -195,248 +196,258 @@ const MentorRegistrationPage = () => {
 
   if (submissionStatus === 'success') {
     return (
-      <Box
-        sx={{
-          minHeight: '100vh',
-          bgcolor: 'custom.lightBlue',
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-          px: 2,
-        }}
-      >
-        <Paper
-          elevation={3}
+      <>
+        <BreadCrumbsDynamic />
+        <Box
           sx={{
-            p: { xs: 4, sm: 6 },
-            borderRadius: 2,
-            maxWidth: '540px',
-            textAlign: 'center',
+            minHeight: '100vh',
+            bgcolor: 'custom.lightBlue',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            px: 2,
           }}
         >
-          <Typography variant="h4" gutterBottom color="success.main">
-            Application Submitted!
-          </Typography>
-          <Typography variant="body1" sx={{ mb: 4 }}>
-            Thank you for applying to be a mentor. Your application has been
-            received and is now being reviewed. We will get back to you soon.
-          </Typography>
-          <Link href="/mentorship" passHref>
-            <Button variant="contained" color="primary">
-              Go to Mentorship Page
-            </Button>
-          </Link>
-        </Paper>
-      </Box>
+          <Paper
+            elevation={3}
+            sx={{
+              p: { xs: 4, sm: 6 },
+              borderRadius: 2,
+              maxWidth: '540px',
+              textAlign: 'center',
+            }}
+          >
+            <Typography variant="h4" gutterBottom color="success.main">
+              Application Submitted!
+            </Typography>
+            <Typography variant="body1" sx={{ mb: 4 }}>
+              Thank you for applying to be a mentor. Your application has been
+              received and is now being reviewed. We will get back to you soon.
+            </Typography>
+            <Link href="/mentorship" passHref>
+              <Button variant="contained" color="primary">
+                Go to Mentorship Page
+              </Button>
+            </Link>
+          </Paper>
+        </Box>
+      </>
     );
   }
 
   return (
-    <FormProvider {...formMethods}>
-      <Box
-        sx={{
-          minHeight: '100vh',
-          bgcolor: 'custom.lightBlue',
-          position: 'relative',
-          overflow: 'hidden',
-          pb: 8,
-        }}
-      >
-        <Container
-          maxWidth={false}
+    <>
+      <BreadCrumbsDynamic />
+      <FormProvider {...formMethods}>
+        <Box
           sx={{
+            minHeight: '100vh',
+            bgcolor: 'custom.lightBlue',
             position: 'relative',
-            zIndex: 1,
-            pt: { xs: 4, sm: 10, md: '18.75rem' },
-            px: { xs: 2, sm: 3 },
-            maxWidth: isMobile ? '100%' : theme.custom.innerBox.maxWidth,
-            margin: '0 auto',
+            overflow: 'hidden',
+            pb: 8,
           }}
         >
-          <Box
-            component="img"
-            src="/mentor-hero-bg.png"
-            alt="Mentor background"
+          <Container
+            maxWidth={false}
             sx={{
-              position: 'absolute',
-              top: '-6.25rem',
-              right: 0,
-              height: { xs: '220px', sm: '280px', md: '360px', lg: '420px' },
-              width: 'auto',
-              zIndex: -1,
-              opacity: 0.9,
-              pointerEvents: 'none',
-            }}
-          />
-          <Paper
-            elevation={3}
-            sx={{
-              p: { xs: 3, sm: 4, md: 5 },
-              borderRadius: 2,
-              width: '100%',
-              maxWidth: { xs: '100%', sm: '540px', md: '640px' },
-              mx: 'auto',
-              bgcolor: 'white',
+              position: 'relative',
+              zIndex: 1,
+              pt: { xs: 4, sm: 10, md: '18.75rem' },
+              px: { xs: 2, sm: 3 },
+              maxWidth: isMobile ? '100%' : theme.custom.innerBox.maxWidth,
+              margin: '0 auto',
             }}
           >
-            <Typography
-              variant="body2"
-              align="center"
-              sx={{
-                mb: 3,
-                color: 'text.secondary',
-              }}
-            >
-              Step {activeStep} of {totalSteps}
-            </Typography>
-
-            {submissionStatus === 'error' && (
-              <Alert severity="error" sx={{ mb: 3 }}>
-                {errorMessage}
-              </Alert>
-            )}
-
             <Box
+              component="img"
+              src="/mentor-hero-bg.png"
+              alt="Mentor background"
               sx={{
+                position: 'absolute',
+                top: '-6.25rem',
+                right: 0,
+                height: { xs: '220px', sm: '280px', md: '360px', lg: '420px' },
+                width: 'auto',
+                zIndex: -1,
+                opacity: 0.9,
+                pointerEvents: 'none',
+              }}
+            />
+            <Paper
+              elevation={3}
+              sx={{
+                p: { xs: 3, sm: 4, md: 5 },
+                borderRadius: 2,
                 width: '100%',
-                height: 6,
-                bgcolor: '#E5E5E5',
-                borderRadius: 3,
-                mb: 5,
-                overflow: 'hidden',
+                maxWidth: { xs: '100%', sm: '540px', md: '640px' },
+                mx: 'auto',
+                bgcolor: 'white',
               }}
             >
-              <Box
+              <Typography
+                variant="body2"
+                align="center"
                 sx={{
-                  width: `${(activeStep / totalSteps) * 100}%`,
-                  height: '100%',
-                  bgcolor: 'primary.main',
-                  borderRadius: 3,
-                  transition: 'width 0.3s ease',
-                }}
-              />
-            </Box>
-
-            <Box>
-              {activeStep === 1 && <Step1BasicInfo />}
-              {activeStep === 2 && <Step2Skills />}
-              {activeStep === 3 && <Step3DomainSkills />}
-              {activeStep === 4 && <Step4ProgrammingSkills />}
-              {activeStep === 5 && <Step5Review />}
-            </Box>
-
-            <Stack
-              direction="row"
-              justifyContent="space-between"
-              alignItems="center"
-              mt={5}
-              spacing={2}
-            >
-              <Button
-                variant="outlined"
-                disabled={activeStep === 1 || submissionStatus === 'loading'}
-                onClick={handleBack}
-                sx={{
-                  px: { xs: 2.5, md: 3.5 },
-                  py: 1,
+                  mb: 3,
+                  color: 'text.secondary',
                 }}
               >
-                Back
-              </Button>
+                Step {activeStep} of {totalSteps}
+              </Typography>
 
-              <Box sx={{ flexGrow: 1, textAlign: 'center' }}>
-                {Object.keys(formMethods.formState.errors).length > 0 && (
-                  <Box sx={{ mb: 2 }}>
-                    <Typography color="error" variant="subtitle2" gutterBottom>
-                      Please fix the following validation errors:
-                    </Typography>
-                    <ul
-                      style={{
-                        textAlign: 'left',
-                        color: theme.palette.error.main,
-                        margin: '0 auto',
-                        display: 'inline-block',
-                      }}
-                    >
-                      {Object.entries(formMethods.formState.errors).map(
-                        ([key, error]: [string, any]) => {
-                          const label =
-                            {
-                              fullName: 'Full Name',
-                              email: 'Email',
-                              slackDisplayName: 'Slack Name',
-                              country: 'Country',
-                              city: 'City',
-                              position: 'Position',
-                              companyName: 'Company Name',
-                              calendlyLink: 'Calendly Link',
-                              menteeExpectations: 'Mentee Expectations',
-                              openToNonWomen: 'Open to non-women',
-                              isLongTermMentor: 'Mentorship Format',
-                              maxMentees: 'Max Mentees',
-                              adHocAvailability: 'Ad-hoc Availability',
-                              languages: 'Languages',
-                              yearsExperience: 'Years of Experience',
-                              bio: 'Bio',
-                              technicalAreas: 'Technical Areas',
-                              codeLanguages: 'Programming Languages',
-                              mentorshipFocusAreas: 'Mentorship Focus Areas',
-                              linkedin: 'LinkedIn',
-                              identity: 'Identity',
-                              pronouns: 'Pronouns',
-                              socialHighlight: 'Social Highlight',
-                              termsAgreed: 'Terms Agreement',
-                            }[key] || key;
-                          return (
-                            <li key={key}>
-                              <Typography variant="caption">
-                                <strong>{label}:</strong>{' '}
-                                {error?.message || 'Invalid value'}
-                              </Typography>
-                            </li>
-                          );
-                        },
-                      )}
-                    </ul>
-                  </Box>
-                )}
+              {submissionStatus === 'error' && (
+                <Alert severity="error" sx={{ mb: 3 }}>
+                  {errorMessage}
+                </Alert>
+              )}
+
+              <Box
+                sx={{
+                  width: '100%',
+                  height: 6,
+                  bgcolor: '#E5E5E5',
+                  borderRadius: 3,
+                  mb: 5,
+                  overflow: 'hidden',
+                }}
+              >
+                <Box
+                  sx={{
+                    width: `${(activeStep / totalSteps) * 100}%`,
+                    height: '100%',
+                    bgcolor: 'primary.main',
+                    borderRadius: 3,
+                    transition: 'width 0.3s ease',
+                  }}
+                />
               </Box>
 
-              {activeStep === totalSteps ? (
+              <Box>
+                {activeStep === 1 && <Step1BasicInfo />}
+                {activeStep === 2 && <Step2Skills />}
+                {activeStep === 3 && <Step3DomainSkills />}
+                {activeStep === 4 && <Step4ProgrammingSkills />}
+                {activeStep === 5 && <Step5Review />}
+              </Box>
+
+              <Stack
+                direction="row"
+                justifyContent="space-between"
+                alignItems="center"
+                mt={5}
+                spacing={2}
+              >
                 <Button
-                  variant="contained"
-                  color="success"
-                  disabled={submissionStatus === 'loading'}
-                  onClick={formMethods.handleSubmit(onSubmit, onInvalid)}
+                  variant="outlined"
+                  disabled={activeStep === 1 || submissionStatus === 'loading'}
+                  onClick={handleBack}
                   sx={{
                     px: { xs: 2.5, md: 3.5 },
                     py: 1,
-                    minWidth: '120px',
                   }}
                 >
-                  {submissionStatus === 'loading' ? (
-                    <CircularProgress size={24} color="inherit" />
-                  ) : (
-                    'Submit Application'
+                  Back
+                </Button>
+
+                <Box sx={{ flexGrow: 1, textAlign: 'center' }}>
+                  {Object.keys(formMethods.formState.errors).length > 0 && (
+                    <Box sx={{ mb: 2 }}>
+                      <Typography
+                        color="error"
+                        variant="subtitle2"
+                        gutterBottom
+                      >
+                        Please fix the following validation errors:
+                      </Typography>
+                      <ul
+                        style={{
+                          textAlign: 'left',
+                          color: theme.palette.error.main,
+                          margin: '0 auto',
+                          display: 'inline-block',
+                        }}
+                      >
+                        {Object.entries(formMethods.formState.errors).map(
+                          ([key, error]: [string, any]) => {
+                            const label =
+                              {
+                                fullName: 'Full Name',
+                                email: 'Email',
+                                slackDisplayName: 'Slack Name',
+                                country: 'Country',
+                                city: 'City',
+                                position: 'Position',
+                                companyName: 'Company Name',
+                                calendlyLink: 'Calendly Link',
+                                menteeExpectations: 'Mentee Expectations',
+                                openToNonWomen: 'Open to non-women',
+                                isLongTermMentor: 'Mentorship Format',
+                                maxMentees: 'Max Mentees',
+                                adHocAvailability: 'Ad-hoc Availability',
+                                languages: 'Languages',
+                                yearsExperience: 'Years of Experience',
+                                bio: 'Bio',
+                                technicalAreas: 'Technical Areas',
+                                codeLanguages: 'Programming Languages',
+                                mentorshipFocusAreas: 'Mentorship Focus Areas',
+                                linkedin: 'LinkedIn',
+                                identity: 'Identity',
+                                pronouns: 'Pronouns',
+                                socialHighlight: 'Social Highlight',
+                                termsAgreed: 'Terms Agreement',
+                              }[key] || key;
+                            return (
+                              <li key={key}>
+                                <Typography variant="caption">
+                                  <strong>{label}:</strong>{' '}
+                                  {error?.message || 'Invalid value'}
+                                </Typography>
+                              </li>
+                            );
+                          },
+                        )}
+                      </ul>
+                    </Box>
                   )}
-                </Button>
-              ) : (
-                <Button
-                  variant="contained"
-                  onClick={handleNext}
-                  sx={{
-                    px: { xs: 2.5, md: 3.5 },
-                    py: 1,
-                  }}
-                >
-                  Next
-                </Button>
-              )}
-            </Stack>
-          </Paper>
-        </Container>
-      </Box>
-    </FormProvider>
+                </Box>
+
+                {activeStep === totalSteps ? (
+                  <Button
+                    variant="contained"
+                    color="success"
+                    disabled={submissionStatus === 'loading'}
+                    onClick={formMethods.handleSubmit(onSubmit, onInvalid)}
+                    sx={{
+                      px: { xs: 2.5, md: 3.5 },
+                      py: 1,
+                      minWidth: '120px',
+                    }}
+                  >
+                    {submissionStatus === 'loading' ? (
+                      <CircularProgress size={24} color="inherit" />
+                    ) : (
+                      'Submit Application'
+                    )}
+                  </Button>
+                ) : (
+                  <Button
+                    variant="contained"
+                    onClick={handleNext}
+                    sx={{
+                      px: { xs: 2.5, md: 3.5 },
+                      py: 1,
+                    }}
+                  >
+                    Next
+                  </Button>
+                )}
+              </Stack>
+            </Paper>
+          </Container>
+        </Box>
+      </FormProvider>
+    </>
   );
 };
 

--- a/src/pages/mentorship/mentors.tsx
+++ b/src/pages/mentorship/mentors.tsx
@@ -161,7 +161,7 @@ const MentorsPage = () => {
 
   return (
     <>
-      {isMobile ? null : <BreadCrumbsDynamic />}
+      <BreadCrumbsDynamic />
       <Title title="Meet Our Mentors" />
       <Box sx={theme.custom.containerBox}>
         {/* Filter / Search bar */}

--- a/src/pages/mentorship/resources.tsx
+++ b/src/pages/mentorship/resources.tsx
@@ -4,7 +4,6 @@ import { GetServerSideProps } from 'next';
 import React from 'react';
 
 import { Title, ResourcesCard, Footer, BreadCrumbsDynamic } from '@components';
-import { useIsMobile } from '@utils/theme-utils';
 import { FooterResponse, MentorshipResourcesResponse } from '@utils/types';
 import { fetchData } from 'lib/api';
 import footerData from 'lib/responses/footer.json';
@@ -16,12 +15,11 @@ type CombinedResponse = {
 };
 
 const MentorshipResourcesPage: React.FC = () => {
-  const isMobile = useIsMobile();
   const { heroTitle, heroDescription, resources } = pageData;
 
   return (
     <>
-      {isMobile ? null : <BreadCrumbsDynamic />}
+      <BreadCrumbsDynamic />
 
       <Box
         sx={{ display: 'flex', flexDirection: 'column', minHeight: '100vh' }}

--- a/src/pages/mentorship/study-groups.tsx
+++ b/src/pages/mentorship/study-groups.tsx
@@ -9,7 +9,6 @@ import {
   Footer,
   BreadCrumbsDynamic,
 } from '@components';
-import { useIsMobile } from '@utils/theme-utils';
 import { FooterResponse, StudyGroupsPageData } from '@utils/types';
 import { fetchData } from 'lib/api';
 
@@ -28,11 +27,10 @@ const MentorShipStudyGroupsPage = ({ data, footer }: StudyGroupsPageProps) => {
 
   const muiTheme = useTheme();
   const cardColors = muiTheme.palette.custom.studyGroupCardColors;
-  const isMobile = useIsMobile();
 
   return (
     <Box>
-      {isMobile ? null : <BreadCrumbsDynamic />}
+      <BreadCrumbsDynamic />
       <HeroWithImage
         title={data.heroSection.title}
         imageSrc={'/hero-img.jpg'} // @TODO replace with actual path?


### PR DESCRIPTION


## Description
<!--- Why is this change required? What problem does it solve? -->
Breadcrumbs were inconsistent across pages (missing, conditionally rendered, or implemented differently).

<!--- If it fixes an open issue, please link to the issue here. -->
[issue #201](https://github.com/Women-Coding-Community/wcc-frontend/issues/201)

<!--- Describe your changes in detail -->
This PR:
- unifies usage of `BreadCrumbsDynamic`
- removes inconsistent `isMobile` conditions
- replaces custom breadcrumbs with the shared component
- adds consistent spacing to breadcrumbs
- updates tests to mock router pathname


## Type

- [x] Bug Fix
- [ ] New Feature
- [ ] Code Refactor
- [ ] Documentation
- [ ] Other

## Related Issue

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->


## Screenshots

<!--  If you are adding or changing a component or page, styling it is mandatory to add a screenshot of your work. -->
<!-- If your component is not visible at the current time of the application (e.g. creating a reusable component before using it), add a screenshot how it would look like per the design and when you used it in your local development >
<!--  Please add screenshot from *before* and *after* to simply the code review -->


### BEFORE: 

<img width="491" height="551" alt="Screenshot 2026-05-02 at 22 15 28" src="https://github.com/user-attachments/assets/f87df2e9-9920-4d35-a0f2-5d65825620f1" />

<img width="1128" height="781" alt="Screenshot 2026-05-02 at 22 21 39" src="https://github.com/user-attachments/assets/ca255f68-3f14-485d-91bb-b98e2c73292a" />

<img width="541" height="558" alt="Screenshot 2026-05-02 at 22 22 03" src="https://github.com/user-attachments/assets/d4a6adba-fcba-4725-80ff-615d6a11d0c2" />

<img width="1129" height="693" alt="Screenshot 2026-05-02 at 22 28 51" src="https://github.com/user-attachments/assets/3646315f-b292-4441-bed8-c31c93e6e395" />


### AFTER:

<img width="1130" height="674" alt="Screenshot 2026-05-02 at 23 00 17" src="https://github.com/user-attachments/assets/a5b962ad-b19e-4ab9-bcc8-de2e35b372b3" />

<img width="494" height="617" alt="Screenshot 2026-05-02 at 23 02 23" src="https://github.com/user-attachments/assets/6e4f15a4-aaf1-477b-b49a-b8c367437fc8" />

<img width="1100" height="728" alt="Screenshot 2026-05-02 at 23 02 50" src="https://github.com/user-attachments/assets/664a7674-4ef6-4509-b1c6-66af42930f03" />

<img width="1049" height="660" alt="Screenshot 2026-05-02 at 23 06 58" src="https://github.com/user-attachments/assets/f2f3ee2e-325d-4a0f-8873-fd8d0d3ade22" />


## Testing

<!--  On component level: Ensure you have a unit test in place. -->
<!--  WILL BE IMPLEMENTED LATER: -->
<!--  On page level: Ensure you have added/updated the integration tests. -->

- pnpm test
- pnpm lint:fix
- pnpm format
- pnpm type-check
- pnpm run test:e2e:docker

Note: `pnpm run test:e2e:docker` currently fails with an existing HP-004 Become Mentor section failure. I reproduced the same failure on `main`, so it appears unrelated to this PR.

<!--
If E2E visual tests fail due to screenshot differences and the UI has been changed intentionally, update the reference screenshots by running:

pnpm test:e2e:docker:update

Verify the updated snapshots and commit them as part of this PR.
-->

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] I checked and followed the [contributor guide](../CONTRIBUTING.md)
- [x] I have tested my changes locally.
- [x] I have added a screenshot from the website after I tested it locally

<!--  Thanks for sending a pull request! -->
