### PR TITLE
feat: add mentorship type filter to mentors page (#284)

### DIFF
--- a/src/pages/api/mentors.ts
+++ b/src/pages/api/mentors.ts
@@ -11,11 +11,24 @@ export default async function handler(
     return res.status(405).json({ error: `Method ${req.method} Not Allowed` });
   }
   try {
-    const { keyword, yearsExperience, areas, language, focus } = req.query;
+    const {
+      keyword,
+      mentorshipTypes,
+      yearsExperience,
+      areas,
+      language,
+      focus,
+    } = req.query;
 
     const params = new URLSearchParams();
     if (keyword)
       params.append('keyword', Array.isArray(keyword) ? keyword[0] : keyword);
+    if (mentorshipTypes) {
+      params.append(
+        'mentorshipTypes',
+        Array.isArray(mentorshipTypes) ? mentorshipTypes[0] : mentorshipTypes,
+      );
+    }
     if (yearsExperience)
       params.append(
         'yearsExperience',

--- a/src/pages/mentorship/mentors.tsx
+++ b/src/pages/mentorship/mentors.tsx
@@ -19,7 +19,11 @@ import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
 
 import { BreadCrumbsDynamic, MentorProfileCard, Title } from '@components';
-import { FILTER_EXPERIENCE_OPTIONS } from '@utils/mentorshipConstants';
+import {
+  ALL_MENTORSHIP_TYPES,
+  FILTER_EXPERIENCE_OPTIONS,
+  FILTER_MENTORSHIP_TYPES_OPTIONS,
+} from '@utils/mentorshipConstants';
 import { useIsMobile } from '@utils/theme-utils';
 // eslint-disable-next-line import/order
 import { Mentor } from '@utils/types';
@@ -28,6 +32,7 @@ type FilterSection = {
   types: string[];
   skills: {
     yearsExperience?: number;
+    mentorshipTypes: string[];
     areas: string[];
     languages: string[];
     mentorshipFocus: string[];
@@ -37,6 +42,8 @@ type FilterSection = {
 import theme from 'theme';
 
 const filterYearExperienceOptions = FILTER_EXPERIENCE_OPTIONS;
+const filterMentorshipTypeOptions = FILTER_MENTORSHIP_TYPES_OPTIONS;
+
 const MentorsPage = () => {
   const router = useRouter();
   const isMobile = useIsMobile();
@@ -46,6 +53,8 @@ const MentorsPage = () => {
   const [loading, setLoading] = useState(false);
   const [filtersOpen, setFiltersOpen] = useState(false);
   const [keyword, setKeyword] = useState<string>('');
+  const [selectedMentorshipType, setSelectedMentorshipType] =
+    useState<string>('');
   const [selectedYearsExperience, setSelectedYearsExperience] =
     useState<string>('');
   const [selectedAreas, setSelectedAreas] = useState<string>('');
@@ -59,6 +68,9 @@ const MentorsPage = () => {
   useEffect(() => {
     if (!query) return;
     if (typeof query.keyword === 'string') setKeyword(query.keyword);
+    if (typeof query.mentorshipTypes === 'string') {
+      setSelectedMentorshipType(query.mentorshipTypes);
+    }
     if (typeof query.yearsExperience === 'string') {
       setSelectedYearsExperience(query.yearsExperience);
     } else {
@@ -80,6 +92,7 @@ const MentorsPage = () => {
         const params = new URLSearchParams();
         const filterKeys = [
           'keyword',
+          'mentorshipTypes',
           'yearsExperience',
           'areas',
           'language',
@@ -127,6 +140,7 @@ const MentorsPage = () => {
 
   const applyFilters = (opts?: {
     keyword?: string;
+    mentorshipTypes?: string;
     yearsExperience?: string;
     areas?: string;
     language?: string;
@@ -151,6 +165,7 @@ const MentorsPage = () => {
 
   const handleClearFilters = () => {
     setKeyword('');
+    setSelectedMentorshipType('');
     setSelectedYearsExperience('');
     setSelectedAreas('');
     setSelectedLanguage('');
@@ -260,6 +275,38 @@ const MentorsPage = () => {
                 {/* First row: filter dropdowns */}
                 <Grid item xs={12}>
                   <Box display="flex" flexWrap="wrap" gap={2}>
+                    <FormControl sx={{ minWidth: 120, flex: 1 }}>
+                      <InputLabel id="filter-mentorship-type-label">
+                        Mentorship type
+                      </InputLabel>
+                      <Select
+                        labelId="filter-mentorship-type-label"
+                        value={selectedMentorshipType}
+                        label="Mentorship type"
+                        onChange={(e) => {
+                          const mentorshipType = e.target.value as string;
+                          setSelectedMentorshipType(mentorshipType);
+                          if (
+                            mentorshipType === ALL_MENTORSHIP_TYPES &&
+                            !selectedMentorshipType
+                          ) {
+                            return;
+                          }
+                          applyFilters({
+                            mentorshipTypes:
+                              mentorshipType === ALL_MENTORSHIP_TYPES
+                                ? ''
+                                : mentorshipType,
+                          });
+                        }}
+                      >
+                        {filterMentorshipTypeOptions.map((option) => (
+                          <MenuItem key={option.label} value={option.value}>
+                            {option.label}
+                          </MenuItem>
+                        ))}
+                      </Select>
+                    </FormControl>
                     <FormControl sx={{ minWidth: 120, flex: 1 }}>
                       <InputLabel id="filter-experience-label">
                         Experience

--- a/src/utils/mentorshipConstants.ts
+++ b/src/utils/mentorshipConstants.ts
@@ -27,6 +27,14 @@ export const MENTORSHIP_TYPES: LabelValue[] = [
   { label: 'Ad-Hoc', value: 'AD_HOC' },
 ];
 
+export const ALL_MENTORSHIP_TYPES = 'All';
+
+export const FILTER_MENTORSHIP_TYPES_OPTIONS = [
+  { label: 'All', value: ALL_MENTORSHIP_TYPES },
+  { label: 'Long-term', value: 'Long-Term' },
+  { label: 'Ad-hoc', value: 'Ad-Hoc' },
+] as const;
+
 export const MENTORSHIP_FOCUS_AREAS: LabelValue[] = [
   { label: 'Switch career to IT', value: 'SWITCH_CAREER_TO_IT' },
   { label: 'Grow from beginner to mid-level', value: 'GROW_BEGINNER_TO_MID' },


### PR DESCRIPTION
## Description

Added a mentorship type filter to the mentors page.

This allows users to filter mentors by mentorship type:
- All
- Long-term
- Ad-hoc

The filter updates the page URL query and forwards the existing mentorshipTypes query parameter to the /api/mentors endpoint, which then passes it to the CMS mentors endpoint.

This solves issue #284.

## Type

- [ ] Bug Fix
- [x] New Feature
- [ ] Code Refactor
- [ ] Documentation
- [ ] Other

## Related Issue

Closes #284

## Screenshots

Before / no mentorship type selected:

<img width="1646" height="815" alt="Screenshot 2026-06-25 at 13 28 02" src="https://github.com/user-attachments/assets/2e6c7003-ab96-4f2b-9e6f-09ccf61be6d1" />

Mentorship type dropdown options:

<img width="1655" height="842" alt="Screenshot 2026-06-25 at 13 22 27" src="https://github.com/user-attachments/assets/de81fbb0-db81-4254-8c96-95f8f0e8b50e" />

Long-term filter selected and query forwarded to `/api/mentors`:

<img width="1656" height="912" alt="Screenshot 2026-06-25 at 13 24 45" src="https://github.com/user-attachments/assets/8d697b9a-0238-4645-96bd-f7d34a8fc25f" />

## Testing

Tested locally with API_KEY=local.

Verified:
- the mentorship type filter is displayed on the mentors page
- selecting Long-term updates the URL with mentorshipTypes=Long-Term
- selecting Ad-hoc updates the URL with mentorshipTypes=Ad-Hoc
- selecting All clears the mentorshipTypes query parameter
- /api/mentors forwards the mentorshipTypes query parameter to the CMS mentors endpoint
- verified via Swagger that the local CMS mentors endpoint accepts `mentorshipTypes=Long-Term` and `mentorshipTypes=Ad-Hoc` and returns `200 OK`

<img width="1616" height="920" alt="Screenshot 2026-06-25 at 13 38 56" src="https://github.com/user-attachments/assets/1fd6286d-babf-4dd3-b1b7-b835a474fc79" />

<img width="1620" height="932" alt="Screenshot 2026-06-25 at 13 34 44" src="https://github.com/user-attachments/assets/26334c38-f39d-40e2-81c1-004aed1c41eb" />

The local CMS mentors endpoint currently returns an empty mentors list, so I tested the visible UI behaviour locally and verified the query/API flow separately.

- Ran `pnpm lint`
- Ran `pnpm type-check`
- Ran `pnpm test`
- Ran `pnpm test:e2e:docker`; Playwright reported existing unrelated failures in Become a Mentee content, Home mentor registration text, and Mentorship navigation URL expectations.

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] I checked and followed the [contributor guide](../CONTRIBUTING.md)
- [x] I have tested my changes locally.
- [x] I have added a screenshot from the website after I tested it locally

<!--  Thanks for sending a pull request! -->
