### PR TITLE
Adds conditional rendering of adhoc registration

### DIFF
--- a/playwright-tests/tests/becomeAMentee.page.spec.ts
+++ b/playwright-tests/tests/becomeAMentee.page.spec.ts
@@ -4,7 +4,9 @@ import { HomePage } from '@pages/home.page';
 import { MentorshipPage } from '@pages/mentorship.page';
 
 test('Validate "Become a Mentee" section and Find a Mentor button', async ({
-  page, mentorshipPage, homePage
+  page,
+  mentorshipPage,
+  homePage,
 }) => {
   // Navigate to Mentorship page
   await page.goto('/mentorship');
@@ -22,7 +24,7 @@ test('Validate "Become a Mentee" section and Find a Mentor button', async ({
   ];
 
   await expect(mentorshipPage.menteeListItems).toHaveText(items);
-  
+
   await homePage.findMentorButton.click();
   await expect(page).toHaveURL(/\/mentorship\/mentors/);
 });

--- a/src/__tests__/pages/MenteeRegistrationPage.test.tsx
+++ b/src/__tests__/pages/MenteeRegistrationPage.test.tsx
@@ -22,14 +22,17 @@ jest.mock('next/router', () => ({
   useRouter: () => ({ push: jest.fn(), pathname: '/' }),
 }));
 
-// Mutable flag so individual tests can override the registration state
+// Mutable flags so individual tests can override registration state
 let mockIsRegistrationOpen = true;
+let mockIsAdhocCycle = false;
 
-// Mock the registration toggle
 jest.mock('../../utils/mentorshipConstants', () => ({
   ...jest.requireActual('../../utils/mentorshipConstants'),
   get IS_REGISTRATION_OPEN() {
     return mockIsRegistrationOpen;
+  },
+  get IS_ADHOC_CYCLE() {
+    return mockIsAdhocCycle;
   },
 }));
 
@@ -183,5 +186,119 @@ describe('MenteeRegistrationPage - registration closed', () => {
       screen.getByText(/Long-Term Mentorship programme/i),
     ).toBeInTheDocument();
     expect(screen.queryByText('Step 1 of 3')).not.toBeInTheDocument();
+  });
+});
+
+describe('MenteeRegistrationPage - adhoc cycle', () => {
+  beforeEach(() => {
+    mockIsAdhocCycle = true;
+    globalThis.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: jest.fn().mockResolvedValue([]),
+    });
+  });
+
+  afterEach(() => {
+    mockIsAdhocCycle = false;
+    jest.resetAllMocks();
+  });
+
+  it('shows ad-hoc breadcrumb label', () => {
+    renderPage();
+    expect(
+      screen.getByText('Ad-hoc Mentee Registration'),
+    ).toBeInTheDocument();
+  });
+
+  it('does not render available hours per month field', () => {
+    renderPage();
+    expect(screen.queryByPlaceholderText('e.g. 4')).not.toBeInTheDocument();
+  });
+
+  it('navigates to step 2 without filling available hours', async () => {
+    renderPage();
+
+    fireEvent.change(screen.getByPlaceholderText('Jane Doe'), {
+      target: { value: 'Jane Doe' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('jane@example.com'), {
+      target: { value: 'jane@example.com' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('@jane'), {
+      target: { value: '@jane' },
+    });
+
+    const countrySelect = screen.getByRole('combobox');
+    fireEvent.mouseDown(countrySelect);
+    const countryOption = await screen.findByRole('option', {
+      name: /United Kingdom/i,
+    });
+    fireEvent.click(countryOption);
+
+    fireEvent.change(screen.getByPlaceholderText('London'), {
+      target: { value: 'London' },
+    });
+    fireEvent.change(
+      screen.getByPlaceholderText('e.g. Frontend Developer, Student'),
+      { target: { value: 'Developer' } },
+    );
+    fireEvent.change(screen.getByPlaceholderText('Acme Corp'), {
+      target: { value: 'Tech Corp' },
+    });
+    fireEvent.change(
+      screen.getByPlaceholderText('https://www.linkedin.com/in/yourprofile'),
+      { target: { value: 'https://www.linkedin.com/in/janedoe' } },
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /next/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Step 2 of 3')).toBeInTheDocument();
+    });
+  });
+
+  it('shows session focus field on step 2', async () => {
+    renderPage();
+
+    fireEvent.change(screen.getByPlaceholderText('Jane Doe'), {
+      target: { value: 'Jane Doe' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('jane@example.com'), {
+      target: { value: 'jane@example.com' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('@jane'), {
+      target: { value: '@jane' },
+    });
+
+    const countrySelect = screen.getByRole('combobox');
+    fireEvent.mouseDown(countrySelect);
+    const countryOption = await screen.findByRole('option', {
+      name: /United Kingdom/i,
+    });
+    fireEvent.click(countryOption);
+
+    fireEvent.change(screen.getByPlaceholderText('London'), {
+      target: { value: 'London' },
+    });
+    fireEvent.change(
+      screen.getByPlaceholderText('e.g. Frontend Developer, Student'),
+      { target: { value: 'Developer' } },
+    );
+    fireEvent.change(screen.getByPlaceholderText('Acme Corp'), {
+      target: { value: 'Tech Corp' },
+    });
+    fireEvent.change(
+      screen.getByPlaceholderText('https://www.linkedin.com/in/yourprofile'),
+      { target: { value: 'https://www.linkedin.com/in/janedoe' } },
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /next/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Session focus *')).toBeInTheDocument();
+      expect(
+        screen.queryByText('Mentorship goals *'),
+      ).not.toBeInTheDocument();
+    });
   });
 });

--- a/src/__tests__/pages/MenteeRegistrationPage.test.tsx
+++ b/src/__tests__/pages/MenteeRegistrationPage.test.tsx
@@ -208,12 +208,12 @@ describe('MenteeRegistrationPage - adhoc cycle', () => {
     expect(screen.getByText('Ad-hoc Mentee Registration')).toBeInTheDocument();
   });
 
-  it('does not render available hours per month field', () => {
+  it('renders available hours per month field', () => {
     renderPage();
-    expect(screen.queryByPlaceholderText('e.g. 4')).not.toBeInTheDocument();
+    expect(screen.getByPlaceholderText('e.g. 4')).toBeInTheDocument();
   });
 
-  it('navigates to step 2 without filling available hours', async () => {
+  it('navigates to step 2 after filling required fields', async () => {
     renderPage();
 
     fireEvent.change(screen.getByPlaceholderText('Jane Doe'), {
@@ -247,6 +247,9 @@ describe('MenteeRegistrationPage - adhoc cycle', () => {
       screen.getByPlaceholderText('https://www.linkedin.com/in/yourprofile'),
       { target: { value: 'https://www.linkedin.com/in/janedoe' } },
     );
+    fireEvent.change(screen.getByPlaceholderText('e.g. 4'), {
+      target: { value: '2' },
+    });
 
     fireEvent.click(screen.getByRole('button', { name: /next/i }));
 
@@ -289,6 +292,9 @@ describe('MenteeRegistrationPage - adhoc cycle', () => {
       screen.getByPlaceholderText('https://www.linkedin.com/in/yourprofile'),
       { target: { value: 'https://www.linkedin.com/in/janedoe' } },
     );
+    fireEvent.change(screen.getByPlaceholderText('e.g. 4'), {
+      target: { value: '2' },
+    });
 
     fireEvent.click(screen.getByRole('button', { name: /next/i }));
 

--- a/src/__tests__/pages/MenteeRegistrationPage.test.tsx
+++ b/src/__tests__/pages/MenteeRegistrationPage.test.tsx
@@ -208,9 +208,9 @@ describe('MenteeRegistrationPage - adhoc cycle', () => {
     expect(screen.getByText('Ad-hoc Mentee Registration')).toBeInTheDocument();
   });
 
-  it('renders available hours per month field', () => {
+  it('does not render available hours per month field', () => {
     renderPage();
-    expect(screen.getByPlaceholderText('e.g. 4')).toBeInTheDocument();
+    expect(screen.queryByPlaceholderText('e.g. 4')).not.toBeInTheDocument();
   });
 
   it('navigates to step 2 after filling required fields', async () => {
@@ -247,9 +247,6 @@ describe('MenteeRegistrationPage - adhoc cycle', () => {
       screen.getByPlaceholderText('https://www.linkedin.com/in/yourprofile'),
       { target: { value: 'https://www.linkedin.com/in/janedoe' } },
     );
-    fireEvent.change(screen.getByPlaceholderText('e.g. 4'), {
-      target: { value: '2' },
-    });
 
     fireEvent.click(screen.getByRole('button', { name: /next/i }));
 
@@ -292,9 +289,6 @@ describe('MenteeRegistrationPage - adhoc cycle', () => {
       screen.getByPlaceholderText('https://www.linkedin.com/in/yourprofile'),
       { target: { value: 'https://www.linkedin.com/in/janedoe' } },
     );
-    fireEvent.change(screen.getByPlaceholderText('e.g. 4'), {
-      target: { value: '2' },
-    });
 
     fireEvent.click(screen.getByRole('button', { name: /next/i }));
 

--- a/src/__tests__/pages/MenteeRegistrationPage.test.tsx
+++ b/src/__tests__/pages/MenteeRegistrationPage.test.tsx
@@ -205,9 +205,7 @@ describe('MenteeRegistrationPage - adhoc cycle', () => {
 
   it('shows ad-hoc breadcrumb label', () => {
     renderPage();
-    expect(
-      screen.getByText('Ad-hoc Mentee Registration'),
-    ).toBeInTheDocument();
+    expect(screen.getByText('Ad-hoc Mentee Registration')).toBeInTheDocument();
   });
 
   it('does not render available hours per month field', () => {
@@ -257,7 +255,7 @@ describe('MenteeRegistrationPage - adhoc cycle', () => {
     });
   });
 
-  it('shows session focus field on step 2', async () => {
+  it('shows mentorship goals field on step 2', async () => {
     renderPage();
 
     fireEvent.change(screen.getByPlaceholderText('Jane Doe'), {
@@ -295,10 +293,7 @@ describe('MenteeRegistrationPage - adhoc cycle', () => {
     fireEvent.click(screen.getByRole('button', { name: /next/i }));
 
     await waitFor(() => {
-      expect(screen.getByText('Session focus *')).toBeInTheDocument();
-      expect(
-        screen.queryByText('Mentorship goals *'),
-      ).not.toBeInTheDocument();
+      expect(screen.getByText('Mentorship goals *')).toBeInTheDocument();
     });
   });
 });

--- a/src/__tests__/schemas/menteeSchema.test.ts
+++ b/src/__tests__/schemas/menteeSchema.test.ts
@@ -104,8 +104,4 @@ describe('adhocMenteeFormDefaultValues', () => {
   it('sets mentorshipType to AD_HOC', () => {
     expect(adhocMenteeFormDefaultValues.mentorshipType).toBe('AD_HOC');
   });
-
-  it('sets availableHsMonth to 1', () => {
-    expect(adhocMenteeFormDefaultValues.availableHsMonth).toBe(1);
-  });
 });

--- a/src/__tests__/schemas/menteeSchema.test.ts
+++ b/src/__tests__/schemas/menteeSchema.test.ts
@@ -23,9 +23,7 @@ const validLongTermBase = {
   spokenLanguages: ['English'],
   bio: 'A'.repeat(50),
   mentorshipType: 'LONG_TERM' as const,
-  applications: [
-    { mentorId: 1, priorityOrder: 1, whyMentor: 'A'.repeat(50) },
-  ],
+  applications: [{ mentorId: 1, priorityOrder: 1, whyMentor: 'A'.repeat(50) }],
 };
 
 const validAdhocBase = {
@@ -110,5 +108,4 @@ describe('adhocMenteeFormDefaultValues', () => {
   it('sets availableHsMonth to 1', () => {
     expect(adhocMenteeFormDefaultValues.availableHsMonth).toBe(1);
   });
-
 });

--- a/src/__tests__/schemas/menteeSchema.test.ts
+++ b/src/__tests__/schemas/menteeSchema.test.ts
@@ -1,0 +1,114 @@
+import {
+  adhocMenteeFormDefaultValues,
+  menteeFormSchema,
+} from '../../schemas/menteeSchema';
+
+const validLongTermBase = {
+  fullName: 'Jane Doe',
+  position: 'Developer',
+  email: 'jane@example.com',
+  slackDisplayName: '@jane',
+  companyName: 'Acme Corp',
+  country: { countryCode: 'GB', countryName: 'United Kingdom' },
+  city: 'London',
+  linkedInProfile: 'https://www.linkedin.com/in/janedoe',
+  pronouns: '',
+  availableHsMonth: 4,
+  skills: {
+    yearsExperience: 2,
+    areas: [{ technicalArea: 'FRONTEND', proficiencyLevel: 'INTERMEDIATE' }],
+    languages: [{ language: 'TYPESCRIPT', proficiencyLevel: 'INTERMEDIATE' }],
+    mentorshipFocus: ['GROW_BEGINNER_TO_MID'],
+  },
+  spokenLanguages: ['English'],
+  bio: 'A'.repeat(50),
+  mentorshipType: 'LONG_TERM' as const,
+  applications: [
+    { mentorId: 1, priorityOrder: 1, whyMentor: 'A'.repeat(50) },
+  ],
+};
+
+const validAdhocBase = {
+  ...validLongTermBase,
+  mentorshipType: 'AD_HOC' as const,
+  availableHsMonth: 1,
+};
+
+describe('menteeFormSchema — long-term', () => {
+  it('accepts valid long-term data', () => {
+    const result = menteeFormSchema.safeParse(validLongTermBase);
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects long-term data with no mentorshipFocus', () => {
+    const data = {
+      ...validLongTermBase,
+      skills: { ...validLongTermBase.skills, mentorshipFocus: [] },
+    };
+    const result = menteeFormSchema.safeParse(data);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const paths = result.error.issues.map((i) => i.path.join('.'));
+      expect(paths).toContain('skills.mentorshipFocus');
+    }
+  });
+});
+
+describe('menteeFormSchema — adhoc', () => {
+  it('accepts valid adhoc data', () => {
+    const result = menteeFormSchema.safeParse(validAdhocBase);
+    expect(result.success).toBe(true);
+  });
+
+  it('requires mentorshipFocus for adhoc', () => {
+    const data = {
+      ...validAdhocBase,
+      skills: { ...validAdhocBase.skills, mentorshipFocus: [] },
+    };
+    const result = menteeFormSchema.safeParse(data);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const paths = result.error.issues.map((i) => i.path.join('.'));
+      expect(paths).toContain('skills.mentorshipFocus');
+    }
+  });
+
+  it('accepts adhoc data with mentorshipFocus selected', () => {
+    const result = menteeFormSchema.safeParse(validAdhocBase);
+    expect(result.success).toBe(true);
+  });
+});
+
+describe('menteeFormSchema — availableHsMonth', () => {
+  it('rejects long-term data with availableHsMonth less than 2', () => {
+    const data = { ...validLongTermBase, availableHsMonth: 1 };
+    const result = menteeFormSchema.safeParse(data);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const paths = result.error.issues.map((i) => i.path.join('.'));
+      expect(paths).toContain('availableHsMonth');
+    }
+  });
+
+  it('accepts long-term data with availableHsMonth of 2', () => {
+    const data = { ...validLongTermBase, availableHsMonth: 2 };
+    const result = menteeFormSchema.safeParse(data);
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts adhoc data with availableHsMonth of 1', () => {
+    const result = menteeFormSchema.safeParse(validAdhocBase);
+    expect(result.success).toBe(true);
+  });
+});
+
+describe('adhocMenteeFormDefaultValues', () => {
+  it('sets mentorshipType to AD_HOC', () => {
+    expect(adhocMenteeFormDefaultValues.mentorshipType).toBe('AD_HOC');
+  });
+
+  it('sets availableHsMonth to 1', () => {
+    expect(adhocMenteeFormDefaultValues.availableHsMonth).toBe(1);
+  });
+
+});

--- a/src/components/mentorship/MenteeStep1BasicInfo.tsx
+++ b/src/components/mentorship/MenteeStep1BasicInfo.tsx
@@ -21,6 +21,19 @@ import { COUNTRIES } from '@utils/mentorshipConstants';
 import { inputStyle } from './mentorshipStyles';
 import StepSection from './StepSection';
 
+const boolToRadioValue = (value: boolean | null | undefined): string => {
+  if (value === true) return 'yes';
+  if (value === false) return 'no';
+  if (value === null) return 'unspecified';
+  return '';
+};
+
+const radioValueToBool = (value: string): boolean | null => {
+  if (value === 'yes') return true;
+  if (value === 'no') return false;
+  return null;
+};
+
 const MenteeStep1BasicInfo = () => {
   const {
     register,
@@ -257,20 +270,9 @@ const MenteeStep1BasicInfo = () => {
                 </FormLabel>
                 <RadioGroup
                   row
-                  value={
-                    field.value === true
-                      ? 'yes'
-                      : field.value === false
-                        ? 'no'
-                        : field.value === null
-                          ? 'unspecified'
-                          : ''
-                  }
+                  value={boolToRadioValue(field.value)}
                   onChange={(e) => {
-                    const v = e.target.value;
-                    field.onChange(
-                      v === 'yes' ? true : v === 'no' ? false : null,
-                    );
+                    field.onChange(radioValueToBool(e.target.value));
                   }}
                 >
                   <FormControlLabel

--- a/src/components/mentorship/MenteeStep1BasicInfo.tsx
+++ b/src/components/mentorship/MenteeStep1BasicInfo.tsx
@@ -1,12 +1,9 @@
 import {
   FormControl,
-  FormControlLabel,
   FormHelperText,
   Grid,
   InputLabel,
   MenuItem,
-  Radio,
-  RadioGroup,
   Select,
   TextField,
   Typography,
@@ -20,7 +17,11 @@ import { COUNTRIES } from '@utils/mentorshipConstants';
 import { inputStyle } from './mentorshipStyles';
 import StepSection from './StepSection';
 
-const MenteeStep1BasicInfo = () => {
+interface Props {
+  isAdhoc?: boolean;
+}
+
+const MenteeStep1BasicInfo = ({ isAdhoc = false }: Props) => {
   const {
     register,
     control,
@@ -238,60 +239,37 @@ const MenteeStep1BasicInfo = () => {
           />
         </Grid>
 
-        <Grid item xs={12} md={6}>
-          <Typography
-            variant="subtitle2"
-            sx={{ mb: 0.5, color: 'text.primary' }}
-          >
-            Available hours per month *
-          </Typography>
-          <Controller
-            name="availableHsMonth"
-            control={control}
-            render={({ field, fieldState: { error } }) => (
-              <TextField
-                {...field}
-                type="number"
-                fullWidth
-                placeholder="e.g. 4"
-                error={!!error}
-                helperText={
-                  error?.message ?? 'How many hours can you dedicate per month?'
-                }
-                onChange={(e) => field.onChange(parseInt(e.target.value) || 0)}
-                sx={inputStyle}
-              />
-            )}
-          />
-        </Grid>
-
-        <Grid item xs={12}>
-          <FormControl>
+        {!isAdhoc && (
+          <Grid item xs={12} md={6}>
             <Typography
               variant="subtitle2"
               sx={{ mb: 0.5, color: 'text.primary' }}
             >
-              Mentorship type
+              Available hours per month *
             </Typography>
-            <RadioGroup row value="LONG_TERM">
-              <FormControlLabel
-                value="LONG_TERM"
-                control={<Radio />}
-                label="Long-term"
-                disabled
-              />
-              <FormControlLabel
-                value="AD_HOC"
-                control={<Radio />}
-                label="Ad-hoc (coming soon)"
-                disabled
-              />
-            </RadioGroup>
-            <FormHelperText>
-              Only long-term mentorship is available for this month.
-            </FormHelperText>
-          </FormControl>
-        </Grid>
+            <Controller
+              name="availableHsMonth"
+              control={control}
+              render={({ field, fieldState: { error } }) => (
+                <TextField
+                  {...field}
+                  type="number"
+                  fullWidth
+                  placeholder="e.g. 4"
+                  error={!!error}
+                  helperText={
+                    error?.message ??
+                    'How many hours can you dedicate per month?'
+                  }
+                  onChange={(e) =>
+                    field.onChange(parseInt(e.target.value) || 0)
+                  }
+                  sx={inputStyle}
+                />
+              )}
+            />
+          </Grid>
+        )}
       </Grid>
     </StepSection>
   );

--- a/src/components/mentorship/MenteeStep1BasicInfo.tsx
+++ b/src/components/mentorship/MenteeStep1BasicInfo.tsx
@@ -262,7 +262,7 @@ const MenteeStep1BasicInfo = ({ isAdhoc = false }: Props) => {
                     'How many hours can you dedicate per month?'
                   }
                   onChange={(e) =>
-                    field.onChange(parseInt(e.target.value) || 0)
+                    field.onChange(Number.parseInt(e.target.value) || 0)
                   }
                   sx={inputStyle}
                 />

--- a/src/components/mentorship/MenteeStep1BasicInfo.tsx
+++ b/src/components/mentorship/MenteeStep1BasicInfo.tsx
@@ -1,9 +1,13 @@
 import {
   FormControl,
+  FormControlLabel,
   FormHelperText,
+  FormLabel,
   Grid,
   InputLabel,
   MenuItem,
+  Radio,
+  RadioGroup,
   Select,
   TextField,
   Typography,
@@ -17,11 +21,7 @@ import { COUNTRIES } from '@utils/mentorshipConstants';
 import { inputStyle } from './mentorshipStyles';
 import StepSection from './StepSection';
 
-interface Props {
-  isAdhoc?: boolean;
-}
-
-const MenteeStep1BasicInfo = ({ isAdhoc = false }: Props) => {
+const MenteeStep1BasicInfo = () => {
   const {
     register,
     control,
@@ -239,37 +239,85 @@ const MenteeStep1BasicInfo = ({ isAdhoc = false }: Props) => {
           />
         </Grid>
 
-        {!isAdhoc && (
-          <Grid item xs={12} md={6}>
-            <Typography
-              variant="subtitle2"
-              sx={{ mb: 0.5, color: 'text.primary' }}
-            >
-              Available hours per month *
-            </Typography>
-            <Controller
-              name="availableHsMonth"
-              control={control}
-              render={({ field, fieldState: { error } }) => (
-                <TextField
-                  {...field}
-                  type="number"
-                  fullWidth
-                  placeholder="e.g. 4"
-                  error={!!error}
-                  helperText={
-                    error?.message ??
-                    'How many hours can you dedicate per month?'
+        <Grid item xs={12} md={6}>
+          <Controller
+            name="isWomen"
+            control={control}
+            render={({ field }) => (
+              <FormControl component="fieldset">
+                <FormLabel
+                  component="legend"
+                  sx={{
+                    mb: 0.5,
+                    color: 'text.primary',
+                    typography: 'subtitle2',
+                  }}
+                >
+                  Do you identify as a woman or non-binary?
+                </FormLabel>
+                <RadioGroup
+                  row
+                  value={
+                    field.value === true
+                      ? 'yes'
+                      : field.value === false
+                        ? 'no'
+                        : field.value === null
+                          ? 'unspecified'
+                          : ''
                   }
-                  onChange={(e) =>
-                    field.onChange(Number.parseInt(e.target.value) || 0)
-                  }
-                  sx={inputStyle}
-                />
-              )}
-            />
-          </Grid>
-        )}
+                  onChange={(e) => {
+                    const v = e.target.value;
+                    field.onChange(
+                      v === 'yes' ? true : v === 'no' ? false : null,
+                    );
+                  }}
+                >
+                  <FormControlLabel
+                    value="yes"
+                    control={<Radio />}
+                    label="Yes"
+                  />
+                  <FormControlLabel value="no" control={<Radio />} label="No" />
+                  <FormControlLabel
+                    value="unspecified"
+                    control={<Radio />}
+                    label="Prefer not to say"
+                  />
+                </RadioGroup>
+              </FormControl>
+            )}
+          />
+        </Grid>
+
+        <Grid item xs={12} md={6}>
+          <Typography
+            variant="subtitle2"
+            sx={{ mb: 0.5, color: 'text.primary' }}
+          >
+            Available hours per month *
+          </Typography>
+          <Controller
+            name="availableHsMonth"
+            control={control}
+            render={({ field, fieldState: { error } }) => (
+              <TextField
+                {...field}
+                type="number"
+                fullWidth
+                placeholder="e.g. 4"
+                error={!!error}
+                helperText={
+                  error?.message ?? 'How many hours can you dedicate per month?'
+                }
+                onChange={(e) =>
+                  field.onChange(Number.parseInt(e.target.value) || 0)
+                }
+                sx={inputStyle}
+              />
+            )}
+          />
+        </Grid>
       </Grid>
     </StepSection>
   );

--- a/src/components/mentorship/MenteeStep1BasicInfo.tsx
+++ b/src/components/mentorship/MenteeStep1BasicInfo.tsx
@@ -34,7 +34,7 @@ const radioValueToBool = (value: string): boolean | null => {
   return null;
 };
 
-const MenteeStep1BasicInfo = () => {
+const MenteeStep1BasicInfo = ({ isAdhoc = false }: { isAdhoc?: boolean }) => {
   const {
     register,
     control,
@@ -292,34 +292,37 @@ const MenteeStep1BasicInfo = () => {
           />
         </Grid>
 
-        <Grid item xs={12} md={6}>
-          <Typography
-            variant="subtitle2"
-            sx={{ mb: 0.5, color: 'text.primary' }}
-          >
-            Available hours per month *
-          </Typography>
-          <Controller
-            name="availableHsMonth"
-            control={control}
-            render={({ field, fieldState: { error } }) => (
-              <TextField
-                {...field}
-                type="number"
-                fullWidth
-                placeholder="e.g. 4"
-                error={!!error}
-                helperText={
-                  error?.message ?? 'How many hours can you dedicate per month?'
-                }
-                onChange={(e) =>
-                  field.onChange(Number.parseInt(e.target.value) || 0)
-                }
-                sx={inputStyle}
-              />
-            )}
-          />
-        </Grid>
+        {!isAdhoc && (
+          <Grid item xs={12} md={6}>
+            <Typography
+              variant="subtitle2"
+              sx={{ mb: 0.5, color: 'text.primary' }}
+            >
+              Available hours per month *
+            </Typography>
+            <Controller
+              name="availableHsMonth"
+              control={control}
+              render={({ field, fieldState: { error } }) => (
+                <TextField
+                  {...field}
+                  type="number"
+                  fullWidth
+                  placeholder="e.g. 4"
+                  error={!!error}
+                  helperText={
+                    error?.message ??
+                    'How many hours can you dedicate per month?'
+                  }
+                  onChange={(e) =>
+                    field.onChange(Number.parseInt(e.target.value) || 0)
+                  }
+                  sx={inputStyle}
+                />
+              )}
+            />
+          </Grid>
+        )}
       </Grid>
     </StepSection>
   );

--- a/src/components/mentorship/MenteeStep2Skills.tsx
+++ b/src/components/mentorship/MenteeStep2Skills.tsx
@@ -118,56 +118,54 @@ const MenteeStep2Skills = ({ isAdhoc = false }: Props) => {
         {/* Mentorship goals */}
         <Grid item xs={12}>
           <>
-              <Typography
-                variant="subtitle2"
-                sx={{ fontWeight: 600, mb: 1, color: 'text.primary' }}
-              >
-                Mentorship goals *
-              </Typography>
-              <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
-                Select the goals you want to achieve through mentorship.
-              </Typography>
-              <Controller
-                name="skills.mentorshipFocus"
-                control={control}
-                defaultValue={[]}
-                render={({ field, fieldState: { error } }) => (
-                  <Box>
-                    <FormGroup>
-                      {MENTORSHIP_FOCUS_AREAS.map((area) => (
-                        <FormControlLabel
-                          key={area.value}
-                          control={
-                            <Checkbox
-                              checked={
-                                field.value?.includes(area.value) ?? false
+            <Typography
+              variant="subtitle2"
+              sx={{ fontWeight: 600, mb: 1, color: 'text.primary' }}
+            >
+              Mentorship goals *
+            </Typography>
+            <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+              Select the goals you want to achieve through mentorship.
+            </Typography>
+            <Controller
+              name="skills.mentorshipFocus"
+              control={control}
+              defaultValue={[]}
+              render={({ field, fieldState: { error } }) => (
+                <Box>
+                  <FormGroup>
+                    {MENTORSHIP_FOCUS_AREAS.map((area) => (
+                      <FormControlLabel
+                        key={area.value}
+                        control={
+                          <Checkbox
+                            checked={field.value?.includes(area.value) ?? false}
+                            onChange={(e) => {
+                              if (e.target.checked) {
+                                field.onChange([
+                                  ...(field.value ?? []),
+                                  area.value,
+                                ]);
+                              } else {
+                                field.onChange(
+                                  (field.value ?? []).filter(
+                                    (v: string) => v !== area.value,
+                                  ),
+                                );
                               }
-                              onChange={(e) => {
-                                if (e.target.checked) {
-                                  field.onChange([
-                                    ...(field.value ?? []),
-                                    area.value,
-                                  ]);
-                                } else {
-                                  field.onChange(
-                                    (field.value ?? []).filter(
-                                      (v: string) => v !== area.value,
-                                    ),
-                                  );
-                                }
-                              }}
-                            />
-                          }
-                          label={area.label}
-                        />
-                      ))}
-                    </FormGroup>
-                    {error && (
-                      <FormHelperText error>{error.message}</FormHelperText>
-                    )}
-                  </Box>
-                )}
-              />
+                            }}
+                          />
+                        }
+                        label={area.label}
+                      />
+                    ))}
+                  </FormGroup>
+                  {error && (
+                    <FormHelperText error>{error.message}</FormHelperText>
+                  )}
+                </Box>
+              )}
+            />
           </>
         </Grid>
 

--- a/src/components/mentorship/MenteeStep2Skills.tsx
+++ b/src/components/mentorship/MenteeStep2Skills.tsx
@@ -28,19 +28,25 @@ import StepSection from './StepSection';
 
 const EXPERIENCE_OPTIONS = MENTEE_EXPERIENCE_OPTIONS;
 
-const MenteeStep2Skills = () => {
+interface Props {
+  isAdhoc?: boolean;
+}
+
+const MenteeStep2Skills = ({ isAdhoc = false }: Props) => {
   const {
     control,
     register,
     formState: { errors },
   } = useFormContext();
 
-  const skillsErrors = errors.skills as any;
-
   return (
     <StepSection
       title="Skills & Experience"
-      description="Tell us about your technical background so we can help match you with the right mentor."
+      description={
+        isAdhoc
+          ? "Tell us about your technical background and what you'd like to focus on in your session."
+          : 'Tell us about your technical background so we can help match you with the right mentor.'
+      }
     >
       <Grid container spacing={3}>
         {/* Years of experience */}
@@ -92,9 +98,6 @@ const MenteeStep2Skills = () => {
             groups={TECHNICAL_AREA_GROUPS}
             proficiencyLevels={PROFICIENCY_LEVELS}
           />
-          {skillsErrors?.areas && (
-            <FormHelperText error>{skillsErrors.areas.message}</FormHelperText>
-          )}
         </Grid>
 
         {/* Programming languages with proficiency */}
@@ -110,63 +113,62 @@ const MenteeStep2Skills = () => {
             languages={CODE_LANGUAGES}
             proficiencyLevels={PROFICIENCY_LEVELS}
           />
-          {skillsErrors?.languages && (
-            <FormHelperText error>
-              {skillsErrors.languages.message}
-            </FormHelperText>
-          )}
         </Grid>
 
-        {/* Mentorship focus */}
+        {/* Mentorship goals */}
         <Grid item xs={12}>
-          <Typography
-            variant="subtitle2"
-            sx={{ fontWeight: 600, mb: 1, color: 'text.primary' }}
-          >
-            Mentorship goals *
-          </Typography>
-          <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
-            Select the goals you want to achieve through mentorship.
-          </Typography>
-          <Controller
-            name="skills.mentorshipFocus"
-            control={control}
-            defaultValue={[]}
-            render={({ field, fieldState: { error } }) => (
-              <Box>
-                <FormGroup>
-                  {MENTORSHIP_FOCUS_AREAS.map((area) => (
-                    <FormControlLabel
-                      key={area.value}
-                      control={
-                        <Checkbox
-                          checked={field.value?.includes(area.value) ?? false}
-                          onChange={(e) => {
-                            if (e.target.checked) {
-                              field.onChange([
-                                ...(field.value ?? []),
-                                area.value,
-                              ]);
-                            } else {
-                              field.onChange(
-                                (field.value ?? []).filter(
-                                  (v: string) => v !== area.value,
-                                ),
-                              );
-                            }
-                          }}
+          <>
+              <Typography
+                variant="subtitle2"
+                sx={{ fontWeight: 600, mb: 1, color: 'text.primary' }}
+              >
+                Mentorship goals *
+              </Typography>
+              <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+                Select the goals you want to achieve through mentorship.
+              </Typography>
+              <Controller
+                name="skills.mentorshipFocus"
+                control={control}
+                defaultValue={[]}
+                render={({ field, fieldState: { error } }) => (
+                  <Box>
+                    <FormGroup>
+                      {MENTORSHIP_FOCUS_AREAS.map((area) => (
+                        <FormControlLabel
+                          key={area.value}
+                          control={
+                            <Checkbox
+                              checked={
+                                field.value?.includes(area.value) ?? false
+                              }
+                              onChange={(e) => {
+                                if (e.target.checked) {
+                                  field.onChange([
+                                    ...(field.value ?? []),
+                                    area.value,
+                                  ]);
+                                } else {
+                                  field.onChange(
+                                    (field.value ?? []).filter(
+                                      (v: string) => v !== area.value,
+                                    ),
+                                  );
+                                }
+                              }}
+                            />
+                          }
+                          label={area.label}
                         />
-                      }
-                      label={area.label}
-                    />
-                  ))}
-                </FormGroup>
-                {error && (
-                  <FormHelperText error>{error.message}</FormHelperText>
+                      ))}
+                    </FormGroup>
+                    {error && (
+                      <FormHelperText error>{error.message}</FormHelperText>
+                    )}
+                  </Box>
                 )}
-              </Box>
-            )}
-          />
+              />
+          </>
         </Grid>
 
         {/* Spoken languages */}

--- a/src/pages/api/mentors.ts
+++ b/src/pages/api/mentors.ts
@@ -11,7 +11,8 @@ export default async function handler(
     return res.status(405).json({ error: `Method ${req.method} Not Allowed` });
   }
   try {
-    const { keyword, yearsExperience, areas, language, focus } = req.query;
+    const { keyword, yearsExperience, areas, language, focus, mentorshipTypes } =
+      req.query;
 
     const params = new URLSearchParams();
     if (keyword)
@@ -28,6 +29,11 @@ export default async function handler(
         Array.isArray(language) ? language[0] : language,
       );
     if (focus) params.append('focus', Array.isArray(focus) ? focus[0] : focus);
+    if (mentorshipTypes)
+      params.append(
+        'mentorshipTypes',
+        Array.isArray(mentorshipTypes) ? mentorshipTypes[0] : mentorshipTypes,
+      );
 
     const data = await proxyRequest('mentorship/mentors', {
       method: 'GET',

--- a/src/pages/mentorship/mentee-registration.tsx
+++ b/src/pages/mentorship/mentee-registration.tsx
@@ -57,9 +57,7 @@ const postMenteeRegistration = async (
   }
 };
 
-const validateStep1LongTerm = async (
-  formMethods: UseFormReturn<MenteeFormData>,
-) =>
+const validateStep1 = async (formMethods: UseFormReturn<MenteeFormData>) =>
   formMethods.trigger([
     'fullName',
     'email',
@@ -70,18 +68,6 @@ const validateStep1LongTerm = async (
     'companyName',
     'linkedInProfile',
     'availableHsMonth',
-  ]);
-
-const validateStep1Adhoc = async (formMethods: UseFormReturn<MenteeFormData>) =>
-  formMethods.trigger([
-    'fullName',
-    'email',
-    'slackDisplayName',
-    'country',
-    'city',
-    'position',
-    'companyName',
-    'linkedInProfile',
   ]);
 
 const validateStep2 = async (formMethods: UseFormReturn<MenteeFormData>) =>
@@ -96,13 +82,9 @@ const validateStep2 = async (formMethods: UseFormReturn<MenteeFormData>) =>
 
 const getStepValidator = (
   step: number,
-  isAdhoc: boolean,
   formMethods: UseFormReturn<MenteeFormData>,
 ): Promise<boolean> => {
-  if (step === 1)
-    return isAdhoc
-      ? validateStep1Adhoc(formMethods)
-      : validateStep1LongTerm(formMethods);
+  if (step === 1) return validateStep1(formMethods);
   if (step === 2) return validateStep2(formMethods);
   return Promise.resolve(true);
 };
@@ -147,7 +129,7 @@ const MenteeRegistrationPage = () => {
   }, [registrationOpen, isAdhoc]);
 
   const handleNext = async () => {
-    const isValid = await getStepValidator(activeStep, isAdhoc, formMethods);
+    const isValid = await getStepValidator(activeStep, formMethods);
     if (isValid && activeStep < TOTAL_STEPS) {
       setActiveStep((prev) => prev + 1);
       window.scrollTo(0, 0);
@@ -164,7 +146,7 @@ const MenteeRegistrationPage = () => {
   const onSubmit = async (data: MenteeFormData) => {
     setSubmitError(null);
 
-    const networkLinks = data.network ?? [];
+    const networkLinks = [...(data.network ?? [])];
     if (data.linkedInProfile) {
       networkLinks.push({
         type: 'LINKEDIN' as const,
@@ -180,9 +162,9 @@ const MenteeRegistrationPage = () => {
         slackDisplayName: data.slackDisplayName,
         country: data.country ?? { countryCode: '', countryName: '' },
         city: data.city,
-        companyName: data.companyName ?? '',
+        companyName: data.companyName,
         pronouns: data.pronouns ?? '',
-        pronounCategory: data.pronounCategory,
+
         isWomen: data.isWomen,
         images: [],
         network: networkLinks,
@@ -250,12 +232,14 @@ const MenteeRegistrationPage = () => {
               px: { xs: 2, sm: 3 },
               maxWidth: isMobile ? '100%' : theme.custom?.innerBox?.maxWidth,
               margin: '0 auto',
-              ...(!registrationOpen && {
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'center',
-                minHeight: '70vh',
-              }),
+              ...(!registrationOpen
+                ? {
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    minHeight: '70vh',
+                  }
+                : {}),
             }}
           >
             <Box
@@ -343,9 +327,7 @@ const MenteeRegistrationPage = () => {
 
                   {/* Step content */}
                   <Box>
-                    {activeStep === 1 && (
-                      <MenteeStep1BasicInfo isAdhoc={isAdhoc} />
-                    )}
+                    {activeStep === 1 && <MenteeStep1BasicInfo />}
                     {activeStep === 2 && (
                       <MenteeStep2Skills isAdhoc={isAdhoc} />
                     )}

--- a/src/pages/mentorship/mentee-registration.tsx
+++ b/src/pages/mentorship/mentee-registration.tsx
@@ -89,6 +89,7 @@ const getStepValidator = (
   return Promise.resolve(true);
 };
 
+// NOSONAR
 const MenteeRegistrationPage = () => {
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('md'));
@@ -412,6 +413,6 @@ const MenteeRegistrationPage = () => {
       </FormProvider>
     </>
   );
-}; //NOSONAR
+};
 
 export default MenteeRegistrationPage;

--- a/src/pages/mentorship/mentee-registration.tsx
+++ b/src/pages/mentorship/mentee-registration.tsx
@@ -232,14 +232,12 @@ const MenteeRegistrationPage = () => {
               px: { xs: 2, sm: 3 },
               maxWidth: isMobile ? '100%' : theme.custom?.innerBox?.maxWidth,
               margin: '0 auto',
-              ...(!registrationOpen
-                ? {
-                    display: 'flex',
-                    alignItems: 'center',
-                    justifyContent: 'center',
-                    minHeight: '70vh',
-                  }
-                : {}),
+              ...(registrationOpen ? {
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                minHeight: '70vh',
+              } : {}),
             }}
           >
             <Box
@@ -412,6 +410,6 @@ const MenteeRegistrationPage = () => {
       </FormProvider>
     </>
   );
-};
+}; //NOSONAR
 
 export default MenteeRegistrationPage;

--- a/src/pages/mentorship/mentee-registration.tsx
+++ b/src/pages/mentorship/mentee-registration.tsx
@@ -27,7 +27,10 @@ import MenteeStep2Skills from 'components/mentorship/MenteeStep2Skills';
 import MenteeStep3Applications from 'components/mentorship/MenteeStep3Applications';
 import { MentorOption } from 'components/mentorship/MentorApplicationCard';
 import RegistrationClosed from 'components/mentorship/RegistrationClosed';
-import { IS_ADHOC_CYCLE, IS_REGISTRATION_OPEN } from 'utils/mentorshipConstants';
+import {
+  IS_ADHOC_CYCLE,
+  IS_REGISTRATION_OPEN,
+} from 'utils/mentorshipConstants';
 
 const TOTAL_STEPS = 3;
 
@@ -46,9 +49,7 @@ const validateStep1LongTerm = async (
     'availableHsMonth',
   ]);
 
-const validateStep1Adhoc = async (
-  formMethods: UseFormReturn<MenteeFormData>,
-) =>
+const validateStep1Adhoc = async (formMethods: UseFormReturn<MenteeFormData>) =>
   formMethods.trigger([
     'fullName',
     'email',
@@ -60,9 +61,7 @@ const validateStep1Adhoc = async (
     'linkedInProfile',
   ]);
 
-const validateStep2 = async (
-  formMethods: UseFormReturn<MenteeFormData>,
-) =>
+const validateStep2 = async (formMethods: UseFormReturn<MenteeFormData>) =>
   formMethods.trigger([
     'skills.yearsExperience',
     'skills.areas',
@@ -93,7 +92,9 @@ const MenteeRegistrationPage = () => {
 
   const formMethods = useForm<MenteeFormData>({
     resolver: zodResolver(menteeFormSchema),
-    defaultValues: isAdhoc ? adhocMenteeFormDefaultValues : menteeFormDefaultValues,
+    defaultValues: isAdhoc
+      ? adhocMenteeFormDefaultValues
+      : menteeFormDefaultValues,
     mode: 'onChange',
   });
 
@@ -120,7 +121,7 @@ const MenteeRegistrationPage = () => {
       .catch(() => {
         // silently fall back to empty list — user can still submit if API is down
       });
-  }, [registrationOpen]);
+  }, [registrationOpen, isAdhoc]);
 
   const handleNext = async () => {
     const isValid = await getStepValidator(activeStep, isAdhoc, formMethods);

--- a/src/pages/mentorship/mentee-registration.tsx
+++ b/src/pages/mentorship/mentee-registration.tsx
@@ -232,12 +232,14 @@ const MenteeRegistrationPage = () => {
               px: { xs: 2, sm: 3 },
               maxWidth: isMobile ? '100%' : theme.custom?.innerBox?.maxWidth,
               margin: '0 auto',
-              ...(registrationOpen ? {
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'center',
-                minHeight: '70vh',
-              } : {}),
+              ...(registrationOpen
+                ? {
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    minHeight: '70vh',
+                  }
+                : {}),
             }}
           >
             <Box

--- a/src/pages/mentorship/mentee-registration.tsx
+++ b/src/pages/mentorship/mentee-registration.tsx
@@ -327,7 +327,9 @@ const MenteeRegistrationPage = () => {
 
                   {/* Step content */}
                   <Box>
-                    {activeStep === 1 && <MenteeStep1BasicInfo isAdhoc={isAdhoc} />}
+                    {activeStep === 1 && (
+                      <MenteeStep1BasicInfo isAdhoc={isAdhoc} />
+                    )}
                     {activeStep === 2 && (
                       <MenteeStep2Skills isAdhoc={isAdhoc} />
                     )}

--- a/src/pages/mentorship/mentee-registration.tsx
+++ b/src/pages/mentorship/mentee-registration.tsx
@@ -60,7 +60,7 @@ const validateStep1Adhoc = async (
     'linkedInProfile',
   ]);
 
-const validateStep2LongTerm = async (
+const validateStep2 = async (
   formMethods: UseFormReturn<MenteeFormData>,
 ) =>
   formMethods.trigger([
@@ -72,17 +72,18 @@ const validateStep2LongTerm = async (
     'bio',
   ]);
 
-const validateStep2Adhoc = async (
+const getStepValidator = (
+  step: number,
+  isAdhoc: boolean,
   formMethods: UseFormReturn<MenteeFormData>,
-) =>
-  formMethods.trigger([
-    'skills.yearsExperience',
-    'skills.areas',
-    'skills.languages',
-    'skills.mentorshipFocus',
-    'spokenLanguages',
-    'bio',
-  ]);
+): Promise<boolean> => {
+  if (step === 1)
+    return isAdhoc
+      ? validateStep1Adhoc(formMethods)
+      : validateStep1LongTerm(formMethods);
+  if (step === 2) return validateStep2(formMethods);
+  return Promise.resolve(true);
+};
 
 const MenteeRegistrationPage = () => {
   const theme = useTheme();
@@ -122,17 +123,7 @@ const MenteeRegistrationPage = () => {
   }, [registrationOpen]);
 
   const handleNext = async () => {
-    let isValid;
-    if (activeStep === 1)
-      isValid = isAdhoc
-        ? await validateStep1Adhoc(formMethods)
-        : await validateStep1LongTerm(formMethods);
-    else if (activeStep === 2)
-      isValid = isAdhoc
-        ? await validateStep2Adhoc(formMethods)
-        : await validateStep2LongTerm(formMethods);
-    else isValid = true;
-
+    const isValid = await getStepValidator(activeStep, isAdhoc, formMethods);
     if (isValid && activeStep < TOTAL_STEPS) {
       setActiveStep((prev) => prev + 1);
       window.scrollTo(0, 0);

--- a/src/pages/mentorship/mentee-registration.tsx
+++ b/src/pages/mentorship/mentee-registration.tsx
@@ -17,6 +17,7 @@ import React, { useEffect, useState } from 'react';
 import { FormProvider, UseFormReturn, useForm } from 'react-hook-form';
 
 import {
+  adhocMenteeFormDefaultValues,
   menteeFormDefaultValues,
   menteeFormSchema,
   MenteeFormData,
@@ -26,11 +27,13 @@ import MenteeStep2Skills from 'components/mentorship/MenteeStep2Skills';
 import MenteeStep3Applications from 'components/mentorship/MenteeStep3Applications';
 import { MentorOption } from 'components/mentorship/MentorApplicationCard';
 import RegistrationClosed from 'components/mentorship/RegistrationClosed';
-import { IS_REGISTRATION_OPEN } from 'utils/mentorshipConstants';
+import { IS_ADHOC_CYCLE, IS_REGISTRATION_OPEN } from 'utils/mentorshipConstants';
 
 const TOTAL_STEPS = 3;
 
-const validateStep1 = async (formMethods: UseFormReturn<MenteeFormData>) =>
+const validateStep1LongTerm = async (
+  formMethods: UseFormReturn<MenteeFormData>,
+) =>
   formMethods.trigger([
     'fullName',
     'email',
@@ -41,10 +44,37 @@ const validateStep1 = async (formMethods: UseFormReturn<MenteeFormData>) =>
     'companyName',
     'linkedInProfile',
     'availableHsMonth',
-    'mentorshipType',
   ]);
 
-const validateStep2 = async (formMethods: UseFormReturn<MenteeFormData>) =>
+const validateStep1Adhoc = async (
+  formMethods: UseFormReturn<MenteeFormData>,
+) =>
+  formMethods.trigger([
+    'fullName',
+    'email',
+    'slackDisplayName',
+    'country',
+    'city',
+    'position',
+    'companyName',
+    'linkedInProfile',
+  ]);
+
+const validateStep2LongTerm = async (
+  formMethods: UseFormReturn<MenteeFormData>,
+) =>
+  formMethods.trigger([
+    'skills.yearsExperience',
+    'skills.areas',
+    'skills.languages',
+    'skills.mentorshipFocus',
+    'spokenLanguages',
+    'bio',
+  ]);
+
+const validateStep2Adhoc = async (
+  formMethods: UseFormReturn<MenteeFormData>,
+) =>
   formMethods.trigger([
     'skills.yearsExperience',
     'skills.areas',
@@ -58,10 +88,11 @@ const MenteeRegistrationPage = () => {
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('md'));
   const registrationOpen = IS_REGISTRATION_OPEN;
+  const isAdhoc = IS_ADHOC_CYCLE;
 
   const formMethods = useForm<MenteeFormData>({
     resolver: zodResolver(menteeFormSchema),
-    defaultValues: menteeFormDefaultValues,
+    defaultValues: isAdhoc ? adhocMenteeFormDefaultValues : menteeFormDefaultValues,
     mode: 'onChange',
   });
 
@@ -72,7 +103,8 @@ const MenteeRegistrationPage = () => {
 
   useEffect(() => {
     if (!registrationOpen) return;
-    fetch('/api/mentors')
+    const mentorshipTypeParam = isAdhoc ? 'Ad-Hoc' : 'Long-Term';
+    fetch(`/api/mentors?mentorshipTypes=${mentorshipTypeParam}`)
       .then((res) => res.json())
       .then((data) => {
         const mentorList: MentorOption[] = (data.mentors ?? data ?? []).map(
@@ -91,8 +123,14 @@ const MenteeRegistrationPage = () => {
 
   const handleNext = async () => {
     let isValid;
-    if (activeStep === 1) isValid = await validateStep1(formMethods);
-    else if (activeStep === 2) isValid = await validateStep2(formMethods);
+    if (activeStep === 1)
+      isValid = isAdhoc
+        ? await validateStep1Adhoc(formMethods)
+        : await validateStep1LongTerm(formMethods);
+    else if (activeStep === 2)
+      isValid = isAdhoc
+        ? await validateStep2Adhoc(formMethods)
+        : await validateStep2LongTerm(formMethods);
     else isValid = true;
 
     if (isValid && activeStep < TOTAL_STEPS) {
@@ -189,7 +227,9 @@ const MenteeRegistrationPage = () => {
           <Link href="/mentorship" color="primary" underline="always">
             Mentorship
           </Link>
-          <Typography color="text.primary">Mentee Registration</Typography>
+          <Typography color="text.primary">
+            {isAdhoc ? 'Ad-hoc Mentee Registration' : 'Mentee Registration'}
+          </Typography>
         </Breadcrumbs>
       </Box>
 
@@ -260,8 +300,9 @@ const MenteeRegistrationPage = () => {
                     color="text.secondary"
                     sx={{ mb: 3 }}
                   >
-                    Thank you for applying to our mentorship programme. We will
-                    review your application and get back to you soon.
+                    {isAdhoc
+                      ? 'Thank you for applying to our ad-hoc mentorship programme. We will review your application and get back to you soon.'
+                      : 'Thank you for applying to our mentorship programme. We will review your application and get back to you soon.'}
                   </Typography>
                   <Button
                     variant="contained"
@@ -304,8 +345,12 @@ const MenteeRegistrationPage = () => {
 
                   {/* Step content */}
                   <Box>
-                    {activeStep === 1 && <MenteeStep1BasicInfo />}
-                    {activeStep === 2 && <MenteeStep2Skills />}
+                    {activeStep === 1 && (
+                      <MenteeStep1BasicInfo isAdhoc={isAdhoc} />
+                    )}
+                    {activeStep === 2 && (
+                      <MenteeStep2Skills isAdhoc={isAdhoc} />
+                    )}
                     {activeStep === 3 && (
                       <MenteeStep3Applications mentors={mentors} />
                     )}

--- a/src/pages/mentorship/mentee-registration.tsx
+++ b/src/pages/mentorship/mentee-registration.tsx
@@ -34,6 +34,29 @@ import {
 
 const TOTAL_STEPS = 3;
 
+const postMenteeRegistration = async (
+  payload: unknown,
+): Promise<string | null> => {
+  try {
+    const response = await fetch('/api/mentee-registration', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+    if (!response.ok) {
+      const body = await response.json().catch(() => null);
+      return (
+        body?.message ??
+        body?.error ??
+        'Something went wrong. Please try again.'
+      );
+    }
+    return null;
+  } catch {
+    return 'Network error. Please check your connection and try again.';
+  }
+};
+
 const validateStep1LongTerm = async (
   formMethods: UseFormReturn<MenteeFormData>,
 ) =>
@@ -177,30 +200,13 @@ const MenteeRegistrationPage = () => {
       })),
     };
 
-    try {
-      const response = await fetch('/api/mentee-registration', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(payload),
-      });
-
-      if (!response.ok) {
-        const body = await response.json().catch(() => null);
-        const message =
-          body?.message ??
-          body?.error ??
-          'Something went wrong. Please try again.';
-        setSubmitError(message);
-        return;
-      }
-
-      setSubmitted(true);
-      window.scrollTo(0, 0);
-    } catch {
-      setSubmitError(
-        'Network error. Please check your connection and try again.',
-      );
+    const error = await postMenteeRegistration(payload);
+    if (error) {
+      setSubmitError(error);
+      return;
     }
+    setSubmitted(true);
+    window.scrollTo(0, 0);
   };
 
   return (

--- a/src/pages/mentorship/mentee-registration.tsx
+++ b/src/pages/mentorship/mentee-registration.tsx
@@ -67,7 +67,6 @@ const validateStep1 = async (formMethods: UseFormReturn<MenteeFormData>) =>
     'position',
     'companyName',
     'linkedInProfile',
-    'availableHsMonth',
   ]);
 
 const validateStep2 = async (formMethods: UseFormReturn<MenteeFormData>) =>
@@ -328,7 +327,7 @@ const MenteeRegistrationPage = () => {
 
                   {/* Step content */}
                   <Box>
-                    {activeStep === 1 && <MenteeStep1BasicInfo />}
+                    {activeStep === 1 && <MenteeStep1BasicInfo isAdhoc={isAdhoc} />}
                     {activeStep === 2 && (
                       <MenteeStep2Skills isAdhoc={isAdhoc} />
                     )}

--- a/src/schemas/menteeSchema.ts
+++ b/src/schemas/menteeSchema.ts
@@ -71,7 +71,10 @@ export const menteeFormSchema = z
       .max(5, 'Maximum 5 mentor selections'),
   })
   .superRefine((data, ctx) => {
-    if (!data.skills.mentorshipFocus || data.skills.mentorshipFocus.length === 0) {
+    if (
+      !data.skills.mentorshipFocus ||
+      data.skills.mentorshipFocus.length === 0
+    ) {
       ctx.addIssue({
         code: 'custom',
         message: 'Select at least one focus area',

--- a/src/schemas/menteeSchema.ts
+++ b/src/schemas/menteeSchema.ts
@@ -16,9 +16,7 @@ const skillsSchema = z.object({
   languages: z
     .array(languageProficiencySchema)
     .min(1, 'Select at least one programming language'),
-  mentorshipFocus: z
-    .array(mentorshipFocusAreaSchema)
-    .min(1, 'Select at least one focus area'),
+  mentorshipFocus: z.array(mentorshipFocusAreaSchema),
 });
 
 const applicationSchema = z.object({
@@ -30,47 +28,66 @@ const applicationSchema = z.object({
   applicationMessage: z.string().optional(),
 });
 
-export const menteeFormSchema = z.object({
-  fullName: z.string().min(2, 'Name must be at least 2 characters'),
-  position: z.string().min(1, 'Position is required'),
-  email: z.email('Please enter a valid email address'),
-  slackDisplayName: z
-    .string()
-    .min(2, 'Slack display name is required')
-    .regex(/^@/, 'Slack name must start with @'),
-  companyName: z.string().min(1, 'Company name is required'),
-  country: countrySchema,
-  city: z.string().min(1, 'Please enter your city'),
-  linkedInProfile: z.url('Please enter a valid LinkedIn URL'),
-  pronouns: z.string(),
-  isWomen: z.boolean({ error: 'Please select an option' }).optional(),
-  pronounCategory: z
-    .enum([
-      'FEMININE',
-      'MASCULINE',
-      'NEUTRAL',
-      'MULTIPLE',
-      'NEOPRONOUNS',
-      'ANY',
-      'UNSPECIFIED',
-    ])
-    .optional(),
-  availableHsMonth: z
-    .number()
-    .min(1, 'Please enter at least 2 hours per month')
-    .max(224, 'Maximum 224 hours per month'),
-  skills: skillsSchema,
-  spokenLanguages: z
-    .array(z.string())
-    .min(1, 'Select at least one spoken language'),
-  bio: z.string().min(50, 'Bio must be at least 50 characters'),
-  network: z.array(networkSchema).optional(),
-  mentorshipType: z.enum(['AD_HOC', 'LONG_TERM']),
-  applications: z
-    .array(applicationSchema)
-    .min(1, 'Please select at least one mentor')
-    .max(5, 'Maximum 5 mentor selections'),
-});
+export const menteeFormSchema = z
+  .object({
+    fullName: z.string().min(2, 'Name must be at least 2 characters'),
+    position: z.string().min(1, 'Position is required'),
+    email: z.email('Please enter a valid email address'),
+    slackDisplayName: z
+      .string()
+      .min(2, 'Slack display name is required')
+      .regex(/^@/, 'Slack name must start with @'),
+    companyName: z.string().min(1, 'Company name is required'),
+    country: countrySchema,
+    city: z.string().min(1, 'Please enter your city'),
+    linkedInProfile: z.url('Please enter a valid LinkedIn URL'),
+    pronouns: z.string(),
+    isWomen: z.boolean({ error: 'Please select an option' }).optional(),
+    pronounCategory: z
+      .enum([
+        'FEMININE',
+        'MASCULINE',
+        'NEUTRAL',
+        'MULTIPLE',
+        'NEOPRONOUNS',
+        'ANY',
+        'UNSPECIFIED',
+      ])
+      .optional(),
+    availableHsMonth: z
+      .number()
+      .min(1, 'Please enter at least 1 hour per month')
+      .max(224, 'Maximum 224 hours per month'),
+    skills: skillsSchema,
+    spokenLanguages: z
+      .array(z.string())
+      .min(1, 'Select at least one spoken language'),
+    bio: z.string().min(50, 'Bio must be at least 50 characters'),
+    network: z.array(networkSchema).optional(),
+    mentorshipType: z.enum(['AD_HOC', 'LONG_TERM']),
+    applications: z
+      .array(applicationSchema)
+      .min(1, 'Please select at least one mentor')
+      .max(5, 'Maximum 5 mentor selections'),
+  })
+  .superRefine((data, ctx) => {
+    if (!data.skills.mentorshipFocus || data.skills.mentorshipFocus.length === 0) {
+      ctx.addIssue({
+        code: 'custom',
+        message: 'Select at least one focus area',
+        path: ['skills', 'mentorshipFocus'],
+      });
+    }
+    if (data.mentorshipType === 'LONG_TERM') {
+      if (data.availableHsMonth < 2) {
+        ctx.addIssue({
+          code: 'custom',
+          message: 'Please enter at least 2 hours per month',
+          path: ['availableHsMonth'],
+        });
+      }
+    }
+  });
 
 export type MenteeFormData = z.infer<typeof menteeFormSchema>;
 
@@ -96,4 +113,10 @@ export const menteeFormDefaultValues: Partial<MenteeFormData> = {
   network: [],
   mentorshipType: 'LONG_TERM',
   applications: [],
+};
+
+export const adhocMenteeFormDefaultValues: Partial<MenteeFormData> = {
+  ...menteeFormDefaultValues,
+  mentorshipType: 'AD_HOC',
+  availableHsMonth: 1,
 };

--- a/src/schemas/menteeSchema.ts
+++ b/src/schemas/menteeSchema.ts
@@ -42,22 +42,9 @@ export const menteeFormSchema = z
     city: z.string().min(1, 'Please enter your city'),
     linkedInProfile: z.url('Please enter a valid LinkedIn URL'),
     pronouns: z.string(),
-    isWomen: z.boolean({ error: 'Please select an option' }).optional(),
-    pronounCategory: z
-      .enum([
-        'FEMININE',
-        'MASCULINE',
-        'NEUTRAL',
-        'MULTIPLE',
-        'NEOPRONOUNS',
-        'ANY',
-        'UNSPECIFIED',
-      ])
-      .optional(),
-    availableHsMonth: z
-      .number()
-      .min(1, 'Please enter at least 1 hour per month')
-      .max(224, 'Maximum 224 hours per month'),
+    isWomen: z.boolean().nullable().optional(),
+
+    availableHsMonth: z.number().min(0).max(224, 'Maximum 224 hours per month'),
     skills: skillsSchema,
     spokenLanguages: z
       .array(z.string())
@@ -81,14 +68,19 @@ export const menteeFormSchema = z
         path: ['skills', 'mentorshipFocus'],
       });
     }
-    if (data.mentorshipType === 'LONG_TERM') {
-      if (data.availableHsMonth < 2) {
-        ctx.addIssue({
-          code: 'custom',
-          message: 'Please enter at least 2 hours per month',
-          path: ['availableHsMonth'],
-        });
-      }
+    if (data.mentorshipType === 'AD_HOC' && data.availableHsMonth < 1) {
+      ctx.addIssue({
+        code: 'custom',
+        message: 'Please enter at least 1 hour per month',
+        path: ['availableHsMonth'],
+      });
+    }
+    if (data.mentorshipType === 'LONG_TERM' && data.availableHsMonth < 2) {
+      ctx.addIssue({
+        code: 'custom',
+        message: 'Please enter at least 2 hours per month',
+        path: ['availableHsMonth'],
+      });
     }
   });
 
@@ -121,5 +113,4 @@ export const menteeFormDefaultValues: Partial<MenteeFormData> = {
 export const adhocMenteeFormDefaultValues: Partial<MenteeFormData> = {
   ...menteeFormDefaultValues,
   mentorshipType: 'AD_HOC',
-  availableHsMonth: 1,
 };

--- a/src/schemas/menteeSchema.ts
+++ b/src/schemas/menteeSchema.ts
@@ -113,4 +113,5 @@ export const menteeFormDefaultValues: Partial<MenteeFormData> = {
 export const adhocMenteeFormDefaultValues: Partial<MenteeFormData> = {
   ...menteeFormDefaultValues,
   mentorshipType: 'AD_HOC',
+  availableHsMonth: 1,
 };

--- a/src/utils/mentorshipConstants.ts
+++ b/src/utils/mentorshipConstants.ts
@@ -201,3 +201,9 @@ export const PREFERENCE_LEVELS = ['Low', 'Medium', 'High', 'Not Applicable'];
  * Set to `true` to open the registration form, `false` to show the closed page.
  */
 export const IS_REGISTRATION_OPEN = false;
+
+/**
+ * Mentorship cycle type toggle.
+ * Set to `true` for an ad-hoc cycle, `false` for a long-term cycle.
+ */
+export const IS_ADHOC_CYCLE = true;

--- a/src/utils/mentorshipConstants.ts
+++ b/src/utils/mentorshipConstants.ts
@@ -208,7 +208,7 @@ export const PREFERENCE_LEVELS = ['Low', 'Medium', 'High', 'Not Applicable'];
  * Mentee registration toggle.
  * Set to `true` to open the registration form, `false` to show the closed page.
  */
-export const IS_REGISTRATION_OPEN = false;
+export const IS_REGISTRATION_OPEN = true;
 
 /**
  * Mentorship cycle type toggle.


### PR DESCRIPTION
## Description

Summary

  - Single registration page now supports both long-term and ad-hoc cycles via IS_ADHOC_CYCLE constant — no new routes
  - Mentor fetch filtered by cycle type using ?mentorshipTypes=Ad-Hoc or ?mentorshipTypes=Long-Term

  Changes

  - IS_ADHOC_CYCLE constant added to mentorshipConstants.ts to toggle cycle type
  - Schema: superRefine enforces mentorshipFocus ≥ 1 for all types; availableHsMonth ≥ 2 for long-term only and availableHsMonth > 1 for adhoc; adhocMenteeFormDefaultValues exported with Mentorship Type
  - Step 1: hides available hours field for ad-hoc; removes mentorship type radio (driven by constant)
  - Step 2: shows ad-hoc description variant; fixed duplicate error messages from child components
  - Registration page: conditional step validation, breadcrumb, success message, and mentor fetch param per cycle type
  - Tests: new menteeSchema.test.ts for conditional validation; adhoc suite added to page tests
  - Adds isWomen dropdown to Form

## Type

- [ ] Bug Fix
- [X] New Feature
- [ ] Code Refactor
- [ ] Documentation
- [ ] Other

## Related Issue


## Screenshots
Registration Open and Its Long Term
<img width="942" height="492" alt="image" src="https://github.com/user-attachments/assets/b46d6f80-e316-4cbd-9080-cff56d4d6db1" />



Correct Available Hours validation
Mentorship Type is not shown
<img width="1384" height="1568" alt="image" src="https://github.com/user-attachments/assets/87e57920-19bf-4a2f-993b-812e1495c761" />

Dual Validation message not shown
<img width="1384" height="1568" alt="image" src="https://github.com/user-attachments/assets/87e57920-19bf-4a2f-993b-812e1495c761" />

Show only cycle relevant mentors
<img width="767" height="687" alt="image" src="https://github.com/user-attachments/assets/06d34047-335f-4181-a715-b60f8b10e3f6" />
<img width="1384" height="501" alt="image" src="https://github.com/user-attachments/assets/120a9e39-6d59-49b1-b94a-715d9faafb4f" />
<img width="780" height="672" alt="image" src="https://github.com/user-attachments/assets/90e9a0de-871d-457f-aa5c-7fdd5eda3db4" />

Adhoc

<img width="955" height="545" alt="image" src="https://github.com/user-attachments/assets/270a257d-f77b-49ce-b214-d07a12c5e1d9" />
<img width="1030" height="540" alt="image" src="https://github.com/user-attachments/assets/915dbcc1-398b-4382-8357-87b5212a5337" />
<img width="1007" height="640" alt="image" src="https://github.com/user-attachments/assets/5f1cde44-e23b-4931-be57-7da40cf4ed5e" />
<img width="1690" height="867" alt="image" src="https://github.com/user-attachments/assets/390e628f-2a81-43e4-b099-22129bfed027" />



## Pull request checklist

Please check if your PR fulfills the following requirements:

- [X] I checked and followed the [contributor guide](../CONTRIBUTING.md)
- [X] I have tested my changes locally.
- [X] I have added a screenshot from the website after I tested it locally

<!--  Thanks for sending a pull request! -->
