### PR TITLE
Fix/288 failing playwright e2e tests

### DIFF
--- a/playwright-tests/pages/base.page.ts
+++ b/playwright-tests/pages/base.page.ts
@@ -32,7 +32,9 @@ export class BasePage {
     this.blogLink = page.getByRole('button', { name: 'Blog' });
     this.jobsLink = page.getByRole('button', { name: 'Jobs' });
     this.aboutUsDropdown = page.getByRole('button', { name: 'About Us' });
-    this.findMentorButton = page.getByRole('button', { name: 'Find a mentor' });
+    this.findMentorButton = page.getByRole('link', {
+      name: 'Check our mentors',
+    });
     this.menuitem = (itemTitle: string) =>
       page.getByRole('menuitem', { name: itemTitle });
 
@@ -60,7 +62,9 @@ export class BasePage {
       Instagram: links.filter({ has: page.getByTestId('InstagramIcon') }),
       Email: links.filter({ has: page.getByTestId('EmailIcon') }),
       Slack: page.locator('a[href*="join.slack.com"]').last(),
-      'Send us a report': page.getByText('Send us a report on GitHub', { exact: true }),
+      'Send us a report': page.getByText('Send us a report on GitHub', {
+        exact: true,
+      }),
     };
   }
 

--- a/playwright-tests/pages/home.page.ts
+++ b/playwright-tests/pages/home.page.ts
@@ -48,7 +48,9 @@ export class HomePage extends BasePage {
       name: 'Learn more about volunteering',
     });
 
-    this.findMentorButton = page.getByRole('button', { name: 'Find a mentor' });
+    this.findMentorButton = page.getByRole('link', {
+      name: 'Check our mentors',
+    });
 
     this.heroTitle = page
       .getByTestId('hero-container')

--- a/playwright-tests/tests/home.page.spec.ts
+++ b/playwright-tests/tests/home.page.spec.ts
@@ -89,9 +89,7 @@ test.describe('Validate Home Page', () => {
     await basePage.clickElement(homePage.joinAsMentorBtn);
 
     await basePage.verifyURL('/mentorship/mentor-registration');
-    await basePage.verifyPageContainsText(
-      'Welcome to the MentorRegistrationPage',
-    );
+    await basePage.verifyPageContainsText('WCC: Registration Form for Mentors');
   });
 
   test('HP-004: Volunteer section', async ({ homePage, basePage }) => {

--- a/playwright-tests/utils/datafactory/nav.tests.ts
+++ b/playwright-tests/utils/datafactory/nav.tests.ts
@@ -57,7 +57,7 @@ export const aboutUsMenuItems = items.map(([name, url, text]) => ({
   expectedText: text,
 }));
 const mentorshipItems = [
-  ['Overview', '/'],
+  ['Overview', '/mentorship'],
   ['Mentors', '/mentorship/mentors'],
   ['Study Groups', '/mentorship/study-groups'],
   ['Resources', '/mentorship/resources'],

--- a/src/lib/responses/mentorship.json
+++ b/src/lib/responses/mentorship.json
@@ -28,7 +28,7 @@
       "uri": "/mentorship/mentors"
     },
     "items": [
-      "Want to start career in software engineering",
+      "Want to start a career in software engineering",
       "Want to find a better job",
       "Want to be promoted at work",
       "Want to apply for a leadership position",


### PR DESCRIPTION
## Description

Fixed existing failing Playwright E2E tests caused by outdated test expectations and outdated fallback mentorship content.

Changes include:

- updated the Become a Mentee fallback content text to use the correct wording: `Want to start a career in software engineering`
- updated the mentor registration page text assertion to match the current page content
- updated the Mentorship Overview navigation expectation from `/` to `/mentorship`
- updated the mentor CTA locator from the old` Find a mentor` label to the current` Check our mentors` label

These changes fix the currently failing Playwright E2E tests that were reproducible on main.

## Type

- [x] Bug Fix
- [ ] New Feature
- [ ] Code Refactor
- [ ] Documentation
- [ ] Other

## Related Issue

Closes #288

## Screenshots

N/A — this PR updates E2E test expectations and fallback content only. No visual UI changes were introduced.

## Testing

Verified locally:

- Ran pnpm test:e2e:docker — 11 passed, 9 skipped
- Ran pnpm test
- Ran pnpm lint
- Ran pnpm type-check

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] I checked and followed the [contributor guide](../CONTRIBUTING.md)
- [x] I have tested my changes locally.
- [ ] I have added a screenshot from the website after I tested it locally

