### PR TITLE
feat: disable mentor apply button when registration is closed (#299)

### DIFF
--- a/src/components/LinkButton.tsx
+++ b/src/components/LinkButton.tsx
@@ -6,6 +6,7 @@ type LinkButtonProps = {
   href: string;
   reversed?: boolean;
   small?: boolean;
+  disabled?: boolean;
   children: React.ReactNode;
   'data-testid'?: string;
 };
@@ -14,10 +15,36 @@ export const LinkButton = ({
   href,
   reversed,
   small,
+  disabled = false,
   children,
   'data-testid': dataTestId,
 }: LinkButtonProps) => {
   const isExternal = href.startsWith('https');
+
+  const buttonSx = {
+    backgroundColor: reversed ? '#fff' : 'primary.main',
+    color: reversed ? 'primary.main' : '#fff',
+    borderRadius: '100px',
+    textTransform: 'none',
+    fontWeight: 600,
+    fontSize: small ? '0.8rem' : '1rem',
+    padding: small ? '7px 16px' : '10px 32px',
+  };
+
+  if (disabled) {
+    return (
+      <Button
+        component="button"
+        type="button"
+        disabled
+        variant="contained"
+        data-testid={dataTestId}
+        sx={buttonSx}
+      >
+        {children}
+      </Button>
+    );
+  }
 
   if (isExternal) {
     return (
@@ -28,15 +55,7 @@ export const LinkButton = ({
         rel="noopener noreferrer"
         variant="contained"
         data-testid={dataTestId}
-        sx={{
-          backgroundColor: reversed ? '#fff' : 'primary.main',
-          color: reversed ? 'primary.main' : '#fff',
-          borderRadius: '100px',
-          textTransform: 'none',
-          fontWeight: 600,
-          fontSize: '1rem',
-          padding: '10px 32px',
-        }}
+        sx={buttonSx}
       >
         {children}
       </Button>
@@ -49,16 +68,7 @@ export const LinkButton = ({
         component="a"
         variant="contained"
         data-testid={dataTestId}
-        sx={{
-          backgroundColor: reversed ? '#fff' : 'primary.main',
-          color: reversed ? 'primary.main' : '#fff',
-          borderRadius: '100px',
-          textTransform: 'none',
-          fontWeight: 600,
-          // width: small ? 'fit-content' : '100%',
-          fontSize: small ? '0.8rem' : '1rem',
-          padding: small ? '7px 16px' : '10px 32px',
-        }}
+        sx={buttonSx}
       >
         {children}
       </Button>

--- a/src/components/MentorProfileCard.tsx
+++ b/src/components/MentorProfileCard.tsx
@@ -8,6 +8,7 @@ import Image from 'next/image';
 import React, { useState } from 'react';
 
 import { LinkButton } from '@components';
+import { IS_REGISTRATION_OPEN } from '@utils/mentorshipConstants';
 import { useIsMobile } from '@utils/theme-utils';
 import { Mentor, Network } from '@utils/types';
 
@@ -130,6 +131,7 @@ export const MentorProfileCard: React.FC<MentorProfileCardProps> = ({
           href={`/mentorship/mentee-registration?id=${mentor.id}`}
           reversed
           small
+          disabled={!IS_REGISTRATION_OPEN}
         >
           Apply for this mentor{' '}
         </LinkButton>

--- a/src/components/__tests__/MentorsProfileCard.tsx
+++ b/src/components/__tests__/MentorsProfileCard.tsx
@@ -70,7 +70,19 @@ const mockMentor: Mentor = {
   },
 };
 
+let mockIsRegistrationOpen = true;
+
+jest.mock('../../utils/mentorshipConstants', () => ({
+  ...jest.requireActual('../../utils/mentorshipConstants'),
+  get IS_REGISTRATION_OPEN() {
+    return mockIsRegistrationOpen;
+  },
+}));
+
 describe('MentorProfileCard', () => {
+  beforeEach(() => {
+    mockIsRegistrationOpen = true;
+  });
   it('renders mentor basic info', () => {
     render(<MentorProfileCard mentor={mockMentor} />);
     expect(screen.getByText('Test Mentor')).toBeInTheDocument();
@@ -115,10 +127,18 @@ describe('MentorProfileCard', () => {
     expect(screen.getAllByTestId('StarIcon').length).toBe(5);
   });
 
-  it('renders the Apply for this mentor button', () => {
+  it('renders the Apply for this mentor link when registration is open', () => {
     render(<MentorProfileCard mentor={mockMentor} />);
     expect(
-      screen.getByRole('link', { name: /Apply for this mentor/i }),
+      screen.getByRole('link', { name: /apply for this mentor/i }),
     ).toBeInTheDocument();
+  });
+
+  it('disables Apply button when registration is closed', () => {
+    mockIsRegistrationOpen = false;
+    render(<MentorProfileCard mentor={mockMentor} />);
+    expect(
+      screen.getByRole('button', { name: /apply for this mentor/i }),
+    ).toBeDisabled();
   });
 });


### PR DESCRIPTION
## Description

Disabled the “Apply for this mentor” action on mentor cards when mentorship registration is closed.

This change:

- adds disabled state support to the shared LinkButton component;
- uses the existing IS_REGISTRATION_OPEN flag to control the Apply action on MentorProfileCard;
- renders the Apply action as a disabled button when registration is closed, instead of an active link.

This prevents users from trying to apply for mentors when registration is not currently available.

## Type

- [ ] Bug Fix
- [x] New Feature
- [ ] Code Refactor
- [ ] Documentation
- [ ] Other

## Related Issue

Closes #299

## Screenshots

Added screenshots showing the Mentors page with the “Apply for this mentor” button disabled when registration is closed.

BEFORE:
<img width="1476" height="908" alt="Screenshot 2026-06-26 at 20 04 29" src="https://github.com/user-attachments/assets/6db10df3-d884-452d-a2bc-94fef7a041ee" />

AFTER:
<img width="1481" height="913" alt="Screenshot 2026-06-26 at 20 02 03" src="https://github.com/user-attachments/assets/494f83cc-5506-4c33-a25f-9e64e6cafe2a" />

## Testing

- Verified locally with the existing Mentor Filter API.
- Confirmed that the local database contains a June AD_HOC mentorship cycle and mentors with June availability.
- Updated the local June AD_HOC cycle status to open for testing.
- Verified that mentors with availability are returned by `/api/cms/v1/mentorship/mentors` and displayed on the Mentors page.
- Verified that the “Apply for this mentor” button is disabled when `IS_REGISTRATION_OPEN` is `false`.
- Verified that the Apply action is rendered as a link when `IS_REGISTRATION_OPEN` is `true`.
- Updated `MentorProfileCard` component tests to cover both open and closed registration states.

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] I checked and followed the [contributor guide](../CONTRIBUTING.md)
- [x] I have tested my changes locally.
- [x] I have added a screenshot from the website after I tested it locally
