### PR TITLE
Mentorship resource images

### DIFF
--- a/playwright-tests/tests/home.page.spec.ts
+++ b/playwright-tests/tests/home.page.spec.ts
@@ -89,7 +89,9 @@ test.describe('Validate Home Page', () => {
     await basePage.clickElement(homePage.joinAsMentorBtn);
 
     await basePage.verifyURL('/mentorship/mentor-registration');
-    await basePage.verifyPageContainsText('WCC: Registration Form for Mentors');
+    await basePage.verifyPageContainsText(
+      'WCC: Registration Form for Mentors',
+    );
   });
 
   test('HP-004: Volunteer section', async ({ homePage, basePage }) => {

--- a/src/components/ResourcesCard.tsx
+++ b/src/components/ResourcesCard.tsx
@@ -67,6 +67,8 @@ export const ResourcesCard: React.FC<ResourcesCardProps> = ({
           variant="contained"
           color="primary"
           href={link}
+          target="_blank"
+          rel="noopener noreferrer"
           sx={{
             textTransform: 'none',
             borderRadius: 2,

--- a/src/components/__tests__/ResourcesCard.test.tsx
+++ b/src/components/__tests__/ResourcesCard.test.tsx
@@ -10,15 +10,20 @@ describe('ResourcesCard', () => {
     title: 'Test Card',
     description: 'This is a test description',
     buttonText: 'Click Me',
-    link: '#',
+    link: 'https://drive.google.com/file/d/1xPbW8BlQoLXkuAJ7m0RuvOV02Opyr445',
   };
 
-  it('renders the title, description, button, and image', () => {
+  it('renders the title, description, button, link, and image', () => {
     render(<ResourcesCard {...props} />);
 
     expect(screen.getByText('Test Card')).toBeInTheDocument();
     expect(screen.getByText('This is a test description')).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: 'Click Me' })).toBeInTheDocument();
+    const link = screen.getByRole('link', { name: 'Click Me' });
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute(
+      'href',
+      'https://drive.google.com/file/d/1xPbW8BlQoLXkuAJ7m0RuvOV02Opyr445',
+    );
 
     const img = screen.getByRole('img');
     expect(img).toHaveAttribute('src', '/test.jpg');

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -11,6 +11,7 @@ import mentors from './responses/mentors.json';
 import mentorShipPage from './responses/mentorship.json';
 import mentorShipCodeOfConduct from './responses/mentorshipCodeOfConduct.json';
 import mentorshipFaqPageData from './responses/mentorshipFaqPage.json';
+import mentorshipResourcesPage from './responses/mentorshipResources.json';
 import studyGroupsPage from './responses/mentorshipStudyGroupsPage.json';
 
 const apiBaseUrl = process.env.API_BASE_URL;
@@ -67,6 +68,7 @@ const pageData = {
   'mentorship/code-of-conduct': mentorShipCodeOfConduct,
   team: aboutUsTeam,
   'mentorship/faq': mentorshipFaqPageData,
+  'mentorship/resources': mentorshipResourcesPage,
   'mentorship/study-groups': studyGroupsPage,
 };
 

--- a/src/lib/responses/mentorshipResources.json
+++ b/src/lib/responses/mentorshipResources.json
@@ -1,28 +1,54 @@
 {
-  "heroTitle": "Mentorship Resources",
-  "heroDescription": "Whether you’re a mentee looking to navigate your journey, a mentor aiming to provide the best guidance, or a seasoned mentor seeking quick tips, we have the tools you need. Explore our guides for insightful mentorship advice and strategies.",
-  "resources": [
-    {
-      "image": "/mentee_guideMedia.jpg",
-      "title": "Mentee’s Guide",
-      "description": "",
-      "buttonText": "View Guide",
-      "link": "#"
-    },
-    {
-      "image": "/mentor_pocketbookMedia.jpg",
-      "title": "Mentor’s Pocketbook",
-      "description": "",
-      "buttonText": "View Pocketbook",
-      "link": "#"
-    },
-    {
-      "image": "/mentor_guideeMedia.jpg",
-      "title": "Mentor’s Guide",
-      "description": "",
-      "buttonText": "View Guide",
-      "link": "#"
-    }
-  ],
-  "footer": "footerData.json content"
+  "id": "page:MENTORSHIP_RESOURCES",
+  "heroSection": {
+    "title": "Mentorship Resources"
+  },
+  "section": {
+    "description": "Whether you’re a mentee looking to navigate your journey, a mentor aiming to provide the best guidance, or a seasoned mentor seeking quick tips, we have the tools you need. Explore our guides for insightful mentorship advice and strategies."
+  },
+  "resourcesSection": {
+    "title": "Available Resources",
+    "description": "Download and explore our curated mentorship materials",
+    "items": [
+      {
+        "title": "Mentees Guide",
+        "description": "A practical guide for mentees to get the most out of mentorship.",
+        "link": {
+          "label": "Download PDF",
+          "uri": "https://drive.google.com/file/d/1xPbW8BlQoLXkuAJ7m0RuvOV02Opyr445"
+        },
+        "image": {
+          "path": "/mentee_guideMedia.jpg",
+          "alt": "woman working on a laptop",
+          "type": "desktop"
+        }
+      },
+      {
+        "title": "Mentor's Pocketbook",
+        "description": "Quick mentor reference notes and useful mentorship tips.",
+        "link": {
+          "label": "Download PDF",
+          "uri": "https://drive.google.com/file/d/1rgoOTqqG4Gu6e4tw45efFspDnoYRgYd9"
+        },
+        "image": {
+          "path": "/mentor_pocketbookMedia.jpg",
+          "alt": "Image decorative",
+          "type": "desktop"
+        }
+      },
+      {
+        "title": "Mentor's Guide",
+        "description": "Guidance and best practices for mentors to support their mentees effectively.",
+        "link": {
+          "label": "Download PDF",
+          "uri": "https://drive.google.com/file/d/1wTkCSG95BVg-0XX4r7FnFiV24_SXlbM_"
+        },
+        "image": {
+          "path": "/mentor_guideeMedia.jpg",
+          "alt": "two women sitting by a desk and talking together",
+          "type": "desktop"
+        }
+      }
+    ]
+  }
 }

--- a/src/pages/mentorship/resources.tsx
+++ b/src/pages/mentorship/resources.tsx
@@ -7,7 +7,6 @@ import { Title, ResourcesCard, Footer, BreadCrumbsDynamic } from '@components';
 import { useIsMobile } from '@utils/theme-utils';
 import { FooterResponse, MentorshipResourcesResponse } from '@utils/types';
 import { fetchData } from 'lib/api';
-import footerData from 'lib/responses/footer.json';
 import pageData from 'lib/responses/mentorshipResources.json';
 
 type CombinedResponse = {
@@ -15,9 +14,18 @@ type CombinedResponse = {
   footer: FooterResponse;
 };
 
-const MentorshipResourcesPage: React.FC = () => {
+type MentorshipResourcesPageProps = {
+  data?: MentorshipResourcesResponse;
+  footer: FooterResponse;
+};
+
+const MentorshipResourcesPage: React.FC<MentorshipResourcesPageProps> = ({
+  data,
+  footer,
+}) => {
   const isMobile = useIsMobile();
-  const { heroTitle, heroDescription, resources } = pageData;
+  const page = (data ?? pageData) as MentorshipResourcesResponse;
+  const { heroSection, section, resourcesSection } = page;
 
   return (
     <>
@@ -27,7 +35,7 @@ const MentorshipResourcesPage: React.FC = () => {
         sx={{ display: 'flex', flexDirection: 'column', minHeight: '100vh' }}
       >
         <Box sx={{ flexGrow: 1 }}>
-          <Title title={heroTitle} />
+          <Title title={heroSection.title} />
 
           <Box
             sx={{
@@ -44,7 +52,7 @@ const MentorshipResourcesPage: React.FC = () => {
                 lineHeight: 1.5,
               }}
             >
-              {heroDescription}
+              {section.description}
             </Typography>
           </Box>
 
@@ -57,14 +65,14 @@ const MentorshipResourcesPage: React.FC = () => {
             }}
           >
             <Grid container spacing={4}>
-              {resources.map((res, index) => (
+              {resourcesSection.items.map((res, index) => (
                 <Grid item xs={12} sm={6} md={6} lg={4} key={index}>
                   <ResourcesCard
-                    image={res.image}
+                    image={res.image.path}
                     title={res.title}
-                    description={res.description}
-                    buttonText={res.buttonText}
-                    link={res.link}
+                    description={res.description ?? ''}
+                    buttonText={res.link.label}
+                    link={res.link.uri}
                     buttonIcon={<OpenInNewIcon />}
                   />
                 </Grid>
@@ -72,7 +80,7 @@ const MentorshipResourcesPage: React.FC = () => {
             </Grid>
           </Box>
         </Box>
-        <Footer {...footerData} />
+        <Footer {...footer} />
       </Box>
     </>
   );

--- a/src/pages/mentorship/resources.tsx
+++ b/src/pages/mentorship/resources.tsx
@@ -7,7 +7,6 @@ import { Title, ResourcesCard, Footer, BreadCrumbsDynamic } from '@components';
 import { useIsMobile } from '@utils/theme-utils';
 import { FooterResponse, MentorshipResourcesResponse } from '@utils/types';
 import { fetchData } from 'lib/api';
-import pageData from 'lib/responses/mentorshipResources.json';
 
 type CombinedResponse = {
   data: MentorshipResourcesResponse;
@@ -19,12 +18,21 @@ type MentorshipResourcesPageProps = {
   footer: FooterResponse;
 };
 
+const resourceImages = [
+  '/mentee_guideMedia.jpg',
+  '/mentor_pocketbookMedia.jpg',
+  '/mentor_guideeMedia.jpg',
+];
+
+const getResourceImage = (index: number) =>
+  resourceImages[index] ?? resourceImages[0];
+
 const MentorshipResourcesPage: React.FC<MentorshipResourcesPageProps> = ({
   data,
   footer,
 }) => {
   const isMobile = useIsMobile();
-  const page = (data ?? pageData) as MentorshipResourcesResponse;
+  const page = data as MentorshipResourcesResponse;
   const { heroSection, section, resourcesSection } = page;
 
   return (
@@ -65,18 +73,22 @@ const MentorshipResourcesPage: React.FC<MentorshipResourcesPageProps> = ({
             }}
           >
             <Grid container spacing={4}>
-              {resourcesSection.items.map((res, index) => (
-                <Grid item xs={12} sm={6} md={6} lg={4} key={index}>
-                  <ResourcesCard
-                    image={res.image.path}
-                    title={res.title}
-                    description={res.description ?? ''}
-                    buttonText={res.link.label}
-                    link={res.link.uri}
-                    buttonIcon={<OpenInNewIcon />}
-                  />
-                </Grid>
-              ))}
+              {resourcesSection.items.map((res, index) => {
+                const resourceImage = getResourceImage(index);
+
+                return (
+                  <Grid item xs={12} sm={6} md={6} lg={4} key={index}>
+                    <ResourcesCard
+                      image={resourceImage}
+                      title={res.title}
+                      description={res.description ?? ''}
+                      buttonText={res.link.label}
+                      link={res.link.uri}
+                      buttonIcon={<OpenInNewIcon />}
+                    />
+                  </Grid>
+                );
+              })}
             </Grid>
           </Box>
         </Box>

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -409,6 +409,7 @@ export type LongTermTimeLineResponse = {
 
 export type ResourceItem = {
   title: string;
+  description?: string;
   link: Link;
   image: Image;
 };

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -411,7 +411,7 @@ export type ResourceItem = {
   title: string;
   description?: string;
   link: Link;
-  image: Image;
+  image: string | Image;
 };
 
 export type ResourcesSection = {


### PR DESCRIPTION
## Description
This PR restores the mentorship resource page changes from #277, which were reverted in #279 due to broken resource card images, and updates the page to use the backend mentorship resources response shape.

## Root Cause

The backend can provide mentorship resource image paths as Google Drive URLs, for example:

`https://drive.google.com/uc?id=<file-id>`

Those URLs are not reliable as direct `<img src="">` values. In the browser, Google Drive may redirect through download/auth flows, or return a response that is not a clean image resource. As a result, the resource cards can show broken images even though the URLs may appear to work when opened directly.

## Fix

- Restores the mentorship resources page to consume the backend response shape.
- Uses API/fallback data for the hero content, resource titles, descriptions, button labels, PDF links, and footer.
- Uses stable local frontend image assets for the three resource card images:
  - `/mentee_guideMedia.jpg`
  - `/mentor_pocketbookMedia.jpg`
  - `/mentor_guideeMedia.jpg`
- Keeps the PDF resource links from the backend data and opens them in a new tab.
- Supports resource image data in the response as either:
  1. An `Image` object with `path`
  2. A string image URL/path

Note: backend image paths are currently not used for the displayed card artwork because Google Drive image URLs are unreliable for direct rendering in resource cards.

## Screenshots

Before
<img width="1193" height="405" alt="Screenshot 2026-06-01 at 21 22 02" src="https://github.com/user-attachments/assets/9f66d34f-12ce-4e0e-b465-262a280a0f6d" />



After
<img width="1385" height="396" alt="Screenshot 2026-06-01 at 21 21 11" src="https://github.com/user-attachments/assets/d0d12b18-e17c-46f5-93a3-eb28f5a522b0" />


<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Type

- [x] Bug Fix
- [ ] New Feature
- [ ] Code Refactor
- [ ] Documentation
- [ ] Other

## Related Issue

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->



<!--  If you are adding or changing a component or page, styling it is mandatory to add a screenshot of your work. -->
<!-- If your component is not visible at the current time of the application (e.g. creating a reusable component before using it), add a screenshot how it would look like per the design and when you used it in your local development >
<!--  Please add screenshot from *before* and *after* to simply the code review -->

## Testing

<!--  On component level: Ensure you have a unit test in place. -->
<!--  WILL BE IMPLEMENTED LATER: -->
<!--  On page level: Ensure you have added/updated the integration tests. -->

<!--
If E2E visual tests fail due to screenshot differences and the UI has been changed intentionally, update the reference screenshots by running:

pnpm test:e2e:docker:update

Verify the updated snapshots and commit them as part of this PR.
-->

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [x] I checked and followed the [contributor guide](../CONTRIBUTING.md)
- [x] I have tested my changes locally.
- [x] I have added a screenshot from the website after I tested it locally

<!--  Thanks for sending a pull request! -->
